### PR TITLE
Various bug fixes in rust sdk

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -2,23 +2,15 @@ name: build wheels
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-  detect-version-changes:
-    uses: ./.github/workflows/check_version.yml
-    with:
-      file_path: bindings/hyperdrivepy/pyproject.toml
-
   build-wheels-linux:
-    needs: detect-version-changes
-    # Run on main if version has changed
-    if: needs.detect-version-changes.outputs.version_changed == 'true'
     name: build on linux
     runs-on: ubuntu-latest
     steps:
@@ -75,9 +67,6 @@ jobs:
           path: ./wheelhouse/*.whl
 
   build-wheels-cibw:
-    needs: detect-version-changes
-    # Run on main if version has changed
-    if: needs.detect-version-changes.outputs.version_changed == 'true'
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -143,11 +132,8 @@ jobs:
           path: ./wheelhouse/*.whl
 
   build-sdist:
-    needs: detect-version-changes
     name: Build source distribution
     runs-on: ubuntu-latest
-    # Run on main if version has changed
-    if: needs.detect-version-changes.outputs.version_changed == 'true'
     steps:
       - uses: actions/checkout@v3
 
@@ -165,14 +151,11 @@ jobs:
         build-wheels-linux,
         build-wheels-cibw,
         build-sdist,
-        detect-version-changes,
       ]
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
       id-token: write
-    # Run on main if version has changed
-    if: needs.detect-version-changes.outputs.version_changed == 'true'
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -1,3 +1,5 @@
+# TODO this workflow isn't used anymore, but we keep this around in case it's useful in the future
+# We likely want to abstract this out used across delv org
 name: Check Version
 
 on:

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -146,6 +146,11 @@ impl State {
             }
         }
 
+        // If the max base amount is less than the minimum transaction amount, we return 0 as the max long.
+        if max_base_amount <= self.minimum_transaction_amount() {
+            return fixed!(0);
+        }
+
         // Ensure that the final result is less than the absolute max and clamp
         // to the budget.
         if max_base_amount >= absolute_max_base_amount {

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -545,7 +545,7 @@ mod tests {
                 }
                 Err(_) => assert!(
                     // Check both panic and err
-                    actual.is_err() or actual.unwrap().is_err()
+                    actual.is_err() || actual.unwrap().is_err()
                 ),
             }
         }

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -118,7 +118,15 @@ impl State {
             if maybe_derivative.is_none() {
                 break;
             }
-            let possible_max_base_amount = max_base_amount + solvency / maybe_derivative.unwrap();
+            let mut possible_max_base_amount =
+                max_base_amount + solvency / maybe_derivative.unwrap();
+
+            // possible_max_base_amount might be less than minimum transaction amount.
+            // we clamp here if so
+            if possible_max_base_amount < self.minimum_transaction_amount() {
+                possible_max_base_amount = self.minimum_transaction_amount();
+            }
+
             maybe_solvency = self.solvency_after_long(
                 possible_max_base_amount,
                 self.calculate_open_long(possible_max_base_amount).unwrap(),

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -81,6 +81,12 @@ impl State {
         // we converge to the solution.
         let mut max_base_amount =
             self.max_long_guess(absolute_max_base_amount, checkpoint_exposure);
+
+        // possible_max_base_amount might be less than minimum transaction amount.
+        // we clamp here if so
+        if max_base_amount < self.minimum_transaction_amount() {
+            max_base_amount = self.minimum_transaction_amount();
+        }
         let mut maybe_solvency = self.solvency_after_long(
             max_base_amount,
             self.calculate_open_long(max_base_amount).unwrap(),

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -609,7 +609,6 @@ mod tests {
                 Ok((expected_base_amount, ..)) => {
                     assert_eq!(actual.unwrap(), FixedPoint::from(expected_base_amount));
                 }
-                //Err(_) => assert!(actual.is_err() || actual == 0),
                 Err(_) => assert!(actual.is_err()),
             }
         }

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -1,5 +1,4 @@
 use ethers::types::I256;
-use eyre::{eyre, Result};
 use fixed_point::FixedPoint;
 use fixed_point_macros::{fixed, int256};
 

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -605,7 +605,7 @@ mod tests {
                 Ok((expected_base_amount, ..)) => {
                     assert_eq!(actual.unwrap(), FixedPoint::from(expected_base_amount));
                 }
-                Err(_) => assert!(actual.is_err()),
+                Err(_) => assert!(actual.is_err() || actual == 0),
             }
         }
 

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -60,7 +60,6 @@ impl State {
         // Calculate the maximum long that brings the spot price to 1. If the pool is
         // solvent after opening this long, then we're done.
         let (absolute_max_base_amount, absolute_max_bond_amount) = self.absolute_max_long();
-
         if self
             .solvency_after_long(
                 absolute_max_base_amount,
@@ -547,15 +546,11 @@ mod tests {
                 .await
             {
                 Ok((expected_base_amount, expected_bond_amount)) => {
-                    // Unwrap twice to handle panic and err
                     let (actual_base_amount, actual_bond_amount) = actual.unwrap();
                     assert_eq!(actual_base_amount, FixedPoint::from(expected_base_amount));
                     assert_eq!(actual_bond_amount, FixedPoint::from(expected_bond_amount));
                 }
-                Err(_) => assert!(
-                    // Check both panic and err
-                    actual.is_err()
-                ),
+                Err(_) => assert!(actual.is_err()),
             }
         }
 

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -318,12 +318,12 @@ impl State {
         let mut maybe_solvency =
             self.solvency_after_short(max_bond_amount, spot_price, checkpoint_exposure);
         if maybe_solvency.is_none() {
-            // If initial guess is insolvant, use the absolute max short
+            // If initial guess is insolvent, use the absolute max short
             // as the initial guess
             max_bond_amount = absolute_max_bond_amount;
             // We expect by definition for the pool to be solvent with the absolute max bond amount.
             maybe_solvency =
-                self.solvency_after_short(max_bond_amount, spot_price, checkpoint_exposure)
+                self.solvency_after_short(max_bond_amount, spot_price, checkpoint_exposure);
         }
         let mut solvency = maybe_solvency.unwrap();
         for _ in 0..maybe_max_iterations.unwrap_or(7) {

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -318,12 +318,7 @@ impl State {
         let mut maybe_solvency =
             self.solvency_after_short(max_bond_amount, spot_price, checkpoint_exposure);
         if maybe_solvency.is_none() {
-            // If initial guess is insolvent, use the absolute max short
-            // as the initial guess
-            max_bond_amount = absolute_max_bond_amount;
-            // We expect by definition for the pool to be solvent with the absolute max bond amount.
-            maybe_solvency =
-                self.solvency_after_short(max_bond_amount, spot_price, checkpoint_exposure);
+            panic!("Initial guess in `absolute_max_short` is insolvent.");
         }
         let mut solvency = maybe_solvency.unwrap();
         for _ in 0..maybe_max_iterations.unwrap_or(7) {

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -318,7 +318,12 @@ impl State {
         let mut maybe_solvency =
             self.solvency_after_short(max_bond_amount, spot_price, checkpoint_exposure);
         if maybe_solvency.is_none() {
-            panic!("Initial guess in `max_short` is insolvent.");
+            // If initial guess is insolvant, use the absolute max short
+            // as the initial guess
+            max_bond_amount = absolute_max_bond_amount;
+            // We expect by definition for the pool to be solvent with the absolute max bond amount.
+            maybe_solvency =
+                self.solvency_after_short(max_bond_amount, spot_price, checkpoint_exposure)
         }
         let mut solvency = maybe_solvency.unwrap();
         for _ in 0..maybe_max_iterations.unwrap_or(7) {

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -7,7 +7,7 @@ python -m pip install --upgrade -r requirements-dev.txt
 python -m pip install auditwheel
 
 echo "nav into the crate so relative paths work"
-cd crates/hyperdrivepy
+cd bindings/hyperdrivepy
 
 echo "build the wheel for the current platform"
 python setup.py bdist_wheel


### PR DESCRIPTION
PR originally from https://github.com/delvtech/hyperdrive/pull/1005

# Resolved Issues
This solves various rust crashes resulting from python fuzz testing.
https://github.com/delvtech/hyperdrive/issues/1004

# Description
Fixes the following issues:
- Max long guesses is below the minimum transaction amount, so `calc_open_long` throws a minimum transaction amount error. We clamp the guess to be minimum transaction amount. and do a final check at the end to ensure the max amount is greater than the minimum transaction amount.
- We catch a case in `absolute_max_long` where the `target_share_reserves < effective_share_reserves`. In this case, we throw a better descriptive panic.
- We short circuit `calc_max_long` and return 0 if the spot price after a minimum long exceeds the max spot price.
- Fixing bug with wheel build script.
- Building and uploading to pypi on tag instead of push to main.

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed. If there are
multiple reviewers, copy the checklists into sections titled `## [Reviewer Name]`.
If the PR doesn't touch Solidity and/or Rust, the corresponding checklist can
be removed.

## [[Reviewer Name]]

### Rust

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
