### PR TITLE
fix calculate_implied_rate to scale according to position duration

### DIFF
--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -570,6 +570,7 @@ mod tests {
             vault.set_rate(variable_rate.into()).send().await?;
 
             // Alice initializes the pool.
+            // TODO: We'd like to set a random position duration & checkpoint duration.
             alice.initialize(fixed_rate, contribution, None).await?;
 
             // Bob opens a short with a random bond amount. Before opening the
@@ -585,7 +586,7 @@ mod tests {
 
             // The term passes and interest accrues.
             chain
-                .increase_time(bob.get_config().position_duration.low_u128())
+            .increase_time(bob.get_config().position_duration.low_u128())
                 .await?;
 
             // Bob closes his short.

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -586,7 +586,7 @@ mod tests {
 
             // The term passes and interest accrues.
             chain
-            .increase_time(bob.get_config().position_duration.low_u128())
+                .increase_time(bob.get_config().position_duration.low_u128())
                 .await?;
 
             // Bob closes his short.

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -158,11 +158,10 @@ impl State {
     /// if the variable rate stays the same. The implied rate is just the ROI
     /// if the variable rate stays the same.
     ///
-    /// To do this, we must adjust the variable rate $r_{adjusted}$ according to
-    /// the annualized position duration $d$ (which equals `position_duration / 365 days`).
-    /// Since we start off from a compounded APY and output a compounded APY with a
-    /// normalizing constant of 1 year, the compounding frequency $f$ is simplified away,
-    /// so the adjusted rate will be:
+    /// To do this, we must figure out the term-adjusted yield $TPY$ according to
+    /// the position duration $t$. Since we start off from a compounded APY and also
+    /// output a compounded TPY, the compounding frequency $f$ is simplified away.
+    /// so the adjusted yield will be:
     ///
     /// $$
     /// APR = f \cdot (( 1 + APY)^{\tfrac{1}{f}}  - 1)
@@ -174,7 +173,7 @@ impl State {
     /// \begin{align}
     /// TPY &= (1 + \frac{APR}{f})^{d \cdot f} \\
     /// &= (1 + APY)^{d} - 1
-    /// \end{align}
+    /// \end{align}make
     /// $$
     pub fn calculate_implied_rate(
         &self,

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -157,14 +157,26 @@ impl State {
     /// will pay and comparing this to the amount of base the short will receive
     /// if the variable rate stays the same. The implied rate is just the ROI
     /// if the variable rate stays the same.
+    ///
+    /// To do this, we must adjust the variable rate $r_{adjusted}$ according to
+    /// the position duration $t$ and the variable yield source's compounding
+    /// frequency $f$. The adjusted rate will be:
+    ///
+    /// $$
+    /// r_{adjusted} = ((1 + r_{variable})^{1/f})^{t*f}-1
+    /// $$
     pub fn calculate_implied_rate(
         &self,
         bond_amount: FixedPoint,
         open_vault_share_price: FixedPoint,
         variable_apy: FixedPoint,
+        compounding_frequency: FixedPoint,
     ) -> Result<I256> {
         let base_paid = self.calculate_open_short(bond_amount, open_vault_share_price)?;
-        let base_proceeds = bond_amount * variable_apy;
+        let base_proceeds = bond_amount
+            * (((fixed!(1e18) + variable_apy).pow(fixed!(1e18) / compounding_frequency))
+                .pow(self.annualized_position_duration() * compounding_frequency)
+                - fixed!(1e18));
         if base_proceeds > base_paid {
             Ok(I256::try_from((base_proceeds - base_paid) / base_paid)?)
         } else {
@@ -532,7 +544,7 @@ mod tests {
     async fn test_calculate_implied_rate() -> Result<()> {
         let tolerance = int256!(1e14);
 
-        // Spwan a test chain with two agents.
+        // Spawn a test chain with two agents.
         let mut rng = thread_rng();
         let chain = TestChain::new().await?;
         let mut alice = chain.alice().await?;
@@ -567,6 +579,7 @@ mod tests {
                 bond_amount,
                 bob.get_state().await?.vault_share_price(),
                 variable_rate.into(),
+                fixed!(365e18),
             )?;
             let (maturity_time, base_paid) = bob.open_short(bond_amount, None, None).await?;
 


### PR DESCRIPTION
PR originally from [delvtech/hyperdrive#1006](https://github.com/delvtech/hyperdrive/pull/1006)

# Resolved Issues
Fixes [delvtech/hyperdrive/#1003 ](https://github.com/delvtech/hyperdrive/issues/1003)

# Description
Fixes calculate_implied_rate to adjust the variable rate according to the term duration and compounding frequency.

We should probably add a test with a position duration different than 1 year, but I couldn't easily figure out how to. 

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed. If there are
multiple reviewers, copy the checklists into sections titled `## [Reviewer Name]`.
If the PR doesn't touch Solidity and/or Rust, the corresponding checklist can
be removed.

## [[Reviewer Name]]

### Rust

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
