### PR TITLE
update latest tag script to be more general

### DIFF
--- a/.github/workflows/rust_lint.yml
+++ b/.github/workflows/rust_lint.yml
@@ -34,7 +34,7 @@ jobs:
           version: nightly
 
       - name: Fetch latest release tag from Hyperdrive
-        run: ./scripts/fetch-latest-tag.sh
+        run: ./scripts/fetch-latest-tag.sh delvtech hyperdrive
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: delvtech/hyperdrive
-          ref: ${{ env.latest_tag }}
+          ref: ${{ env.latest_tag_hyperdrive }}
           path: "./hyperdrive"
 
       - name: build hyperdrive

--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -34,7 +34,7 @@ jobs:
           version: nightly
 
       - name: Fetch latest release tag from Hyperdrive
-        run: ./scripts/fetch-latest-tag.sh
+        run: ./scripts/fetch-latest-tag.sh delvtech hyperdrive
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: delvtech/hyperdrive
-          ref: ${{ env.latest_tag }}
+          ref: ${{ env.latest_tag_hyperdrive }}
           path: "./hyperdrive"
 
       - name: build hyperdrive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "fixed-point-macros"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ethers",
  "fixed-point",
@@ -1500,7 +1500,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdrive-addresses"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ethers",
  "serde",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdrive-math"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ethers",
  "eyre",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdrive-wrappers"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "ethers",
  "ethers-solc",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "async-trait",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
-
 resolver = "2"
 members = [
     "crates/fixed-point",
@@ -8,4 +7,20 @@ members = [
     "crates/hyperdrive-math",
     "crates/hyperdrive-wrappers",
     "crates/test-utils",
+]
+
+[build]
+build = "build.rs"
+
+[workspace.package]
+name="hyperdrive-rs"
+version="0.1.0"
+authors = [
+    "Alex Towle <alex@delv.tech>",
+    "Dylan Paiton <dylan@delv.tech>",
+    "Jonny Rhea <jonny@delv.tech>",
+    "matthew Brown <matt@delv.tech>",
+    "Mihai Cosma <mihai@delv.tech>",
+    "Ryan Goree <ryan@delv.tech>",
+    "Sheng Lundquist <sheng@delv.tech>",
 ]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,53 @@
+use std::{
+    fs,
+    io::{self, Write},
+    path::Path,
+};
+
+fn main() -> io::Result<()> {
+    // Read the Cargo.toml file
+    let cargo_toml = fs::read_to_string("Cargo.toml")?;
+
+    // Parse the version from the workspace
+    let version = cargo_toml
+        .lines()
+        .find(|line| line.starts_with("version"))
+        .map(|line| line.trim().split('"').nth(1).unwrap_or(""))
+        .unwrap();
+
+    // Parse the members from the workspace
+    let members = cargo_toml
+        .lines()
+        .skip_while(|line| !line.starts_with("members = ["))
+        .skip(1)
+        .take_while(|line| !line.starts_with(']'))
+        .filter_map(|line| {
+            if let Some(member) = line.trim().split("/").nth(1) {
+                Some(member.trim_matches(|c| c == '"' || c == ',').to_string())
+            } else {
+                None
+            }
+        });
+
+    // Update the Cargo.toml files for each member
+    for member in members {
+        let member_path = format!("{}{}", "crates/", member);
+        let member_toml_path = Path::new(&member_path).join("Cargo.toml");
+        let mut member_toml = fs::read_to_string(&member_toml_path)?;
+        let member_version = member_toml
+            .lines()
+            .find(|line| line.starts_with("version"))
+            .map(|line| line.trim().split('"').nth(1).unwrap_or(""))
+            .unwrap();
+
+        // Replace the version field
+        member_toml = member_toml.replace(
+            &format!("version = \"{}\"", member_version),
+            &format!("version = \"{}\"", version),
+        );
+
+        fs::write(&member_toml_path, member_toml)?;
+    }
+
+    Ok(())
+}

--- a/crates/fixed-point-macros/Cargo.toml
+++ b/crates/fixed-point-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "fixed-point-macros"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 
 [lib]

--- a/crates/hyperdrive-addresses/Cargo.toml
+++ b/crates/hyperdrive-addresses/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperdrive-addresses"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/hyperdrive-math/Cargo.toml
+++ b/crates/hyperdrive-math/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "hyperdrive-math"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 
 [[test]]

--- a/crates/hyperdrive-wrappers/Cargo.toml
+++ b/crates/hyperdrive-wrappers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperdrive-wrappers"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 
 # Builds the Solidity contract wrappers.

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test-utils"
-version = "0.1.0"
+version = "0.0.0"
 edition = "2021"
 
 [[bin]]

--- a/scripts/fetch-latest-tag.sh
+++ b/scripts/fetch-latest-tag.sh
@@ -1,13 +1,20 @@
 #!/bin/bash
 
+# GitHub organization
+ORG=$1
+
+# GitHub repository name
+REPO=$2
+
 # GitHub Token provided by GitHub Actions
 TOKEN=${GITHUB_TOKEN}
 
-# Repository from which to fetch the latest tag
-REPO='delvtech/hyperdrive'
+# Fetch all tags from the repository
+TAG=$(curl -sH "Authorization: token $TOKEN" "https://api.github.com/repos/$ORG/$REPO/releases/latest" | jq -r '.tag_name')
 
-# Fetch the latest release from GitHub API
-TAG=$(curl -sH "Authorization: token $TOKEN" "https://api.github.com/repos/$REPO/releases/latest" | jq -r '.tag_name')
+# Sanitize repository name to create a valid environment variable name
+# Replace '/' with '_' and convert to lower case
+ENV_REPO_NAME=$(echo "$REPO" | tr '/' '_' | tr '[:upper:]' '[:lower:]')
 
 # Output the tag for subsequent steps
-echo "latest_tag=$TAG" >> $GITHUB_ENV
+echo "latest_tag_${ENV_REPO_NAME}=$TAG" >> $GITHUB_ENV


### PR DESCRIPTION
This sets a single version at the workspace level and uses a build script to prop it to lower crates. It also adds a script for CI that forces hyperdrive-rs to use the latest hyperdrive release when building.