### PR TITLE
fix `calculate_spot_price_after_short` and add open short deltas & preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "fixed-point"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ethers",
  "eyre",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "fixed-point-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ethers",
  "fixed-point",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdrive-addresses"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ethers",
  "serde",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdrive-math"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ethers",
  "eyre",
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdrive-wrappers"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dotenv",
  "ethers",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdrivepy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ethers",
  "eyre",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [workspace.package]
 name="hyperdrive-rs"
-version="0.1.0"
+version="0.1.1"
 authors = [
     "Alex Towle <alex@delv.tech>",
     "Dylan Paiton <dylan@delv.tech>",

--- a/bindings/hyperdrivepy/pyproject.toml
+++ b/bindings/hyperdrivepy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hyperdrivepy"
-version = "0.14.2"
+version = "0.14.3"
 requires-python = ">=3.7"
 classifiers = [
   "Programming Language :: Rust",

--- a/bindings/hyperdrivepy/python/hyperdrivepy/hyperdrive_state.py
+++ b/bindings/hyperdrivepy/python/hyperdrivepy/hyperdrive_state.py
@@ -283,7 +283,7 @@ def calculate_open_short(
     return _get_interface(pool_config, pool_info).calculate_open_short(short_amount, open_vault_share_price)
 
 
-def calculate_open_short_share_adjustment(
+def calculate_open_short_share_reserves_delta(
     pool_config: types.PoolConfigType,
     pool_info: types.PoolInfoType,
     short_amount: str,
@@ -306,7 +306,7 @@ def calculate_open_short_share_adjustment(
     str (FixedPoint)
         The amount of base to add to the pool share reserves.
     """
-    return _get_interface(pool_config, pool_info).calculate_open_short_share_adjustment(short_amount)
+    return _get_interface(pool_config, pool_info).calculate_open_short_share_reserves_delta(short_amount)
 
 
 def calculate_close_short(

--- a/bindings/hyperdrivepy/python/hyperdrivepy/hyperdrive_state.py
+++ b/bindings/hyperdrivepy/python/hyperdrivepy/hyperdrive_state.py
@@ -252,7 +252,7 @@ def calculate_close_long(
 def calculate_open_short(
     pool_config: types.PoolConfigType,
     pool_info: types.PoolInfoType,
-    short_amount: str,
+    bond_amount: str,
     open_vault_share_price: str | None = None,
 ) -> str:
     """Gets the amount of base the trader will need to deposit for a short of a given size.
@@ -265,8 +265,8 @@ def calculate_open_short(
     pool_info: PoolInfo
         Current state information of the hyperdrive contract.
         Includes attributes like reserve levels and share prices.
-    short_amount: str (FixedPoint)
-        The amount to of bonds to short.
+    bond_amount: str (FixedPoint)
+        The amount of bonds to short.
     open_vault_share_price: str (FixedPoint) | None, optional
         Optionally provide the open share price for the short.
         If this is not provided or is None, then we will use the pool's current share price.
@@ -280,15 +280,15 @@ def calculate_open_short(
         # the underlying rust code uses current market share price if this is 0
         # zero value is used because the smart contract will return 0 if the checkpoint hasn't been minted
         open_vault_share_price = "0"
-    return _get_interface(pool_config, pool_info).calculate_open_short(short_amount, open_vault_share_price)
+    return _get_interface(pool_config, pool_info).calculate_open_short(bond_amount, open_vault_share_price)
 
 
-def calculate_open_short_share_reserves_delta(
+def calculate_pool_deltas_after_open_short(
     pool_config: types.PoolConfigType,
     pool_info: types.PoolInfoType,
-    short_amount: str,
+    bond_amount: str,
 ) -> str:
-    """Gets the amount of shares the pool will add after opening a short.
+    """Calculate the share deltas to be applied to the pool after opening a short.
 
     Arguments
     ---------
@@ -298,15 +298,15 @@ def calculate_open_short_share_reserves_delta(
     pool_info: PoolInfo
         Current state information of the hyperdrive contract.
         Includes attributes like reserve levels and share prices.
-    short_amount: str (FixedPoint)
-        The amount to of bonds to short.
+    bond_amount: str (FixedPoint)
+        The amount of bonds to short.
 
     Returns
     -------
     str (FixedPoint)
-        The amount of base to add to the pool share reserves.
+        The amount of shares to add to the pool reserves.
     """
-    return _get_interface(pool_config, pool_info).calculate_open_short_share_reserves_delta(short_amount)
+    return _get_interface(pool_config, pool_info).calculate_pool_deltas_after_open_short(bond_amount)
 
 
 def calculate_close_short(

--- a/bindings/hyperdrivepy/python/hyperdrivepy/hyperdrive_state.py
+++ b/bindings/hyperdrivepy/python/hyperdrivepy/hyperdrive_state.py
@@ -283,6 +283,32 @@ def calculate_open_short(
     return _get_interface(pool_config, pool_info).calculate_open_short(short_amount, open_vault_share_price)
 
 
+def calculate_open_short_share_adjustment(
+    pool_config: types.PoolConfigType,
+    pool_info: types.PoolInfoType,
+    short_amount: str,
+) -> str:
+    """Gets the amount of shares the pool will add after opening a short.
+
+    Arguments
+    ---------
+    pool_config: PoolConfig
+        Static configuration for the hyperdrive contract.
+        Set at deploy time.
+    pool_info: PoolInfo
+        Current state information of the hyperdrive contract.
+        Includes attributes like reserve levels and share prices.
+    short_amount: str (FixedPoint)
+        The amount to of bonds to short.
+
+    Returns
+    -------
+    str (FixedPoint)
+        The amount of base to add to the pool share reserves.
+    """
+    return _get_interface(pool_config, pool_info).calculate_open_short_share_adjustment(short_amount)
+
+
 def calculate_close_short(
     pool_config: types.PoolConfigType,
     pool_info: types.PoolInfoType,

--- a/bindings/hyperdrivepy/setup.py
+++ b/bindings/hyperdrivepy/setup.py
@@ -5,7 +5,7 @@ from setuptools_rust import Binding, RustExtension
 
 setup(
     name="hyperdrivepy",
-    version="0.14.2",
+    version="0.14.3",
     packages=["hyperdrivepy"],
     package_dir={"": "python"},
     rust_extensions=[

--- a/bindings/hyperdrivepy/src/hyperdrive_state_methods.rs
+++ b/bindings/hyperdrivepy/src/hyperdrive_state_methods.rs
@@ -150,11 +150,11 @@ impl HyperdriveState {
 
     pub fn calculate_open_short(
         &self,
-        short_amount: &str,
+        bond_amount: &str,
         open_vault_share_price: &str,
     ) -> PyResult<String> {
-        let short_amount_fp = FixedPoint::from(U256::from_dec_str(short_amount).map_err(|_| {
-            PyErr::new::<PyValueError, _>("Failed to convert short_amount string to U256")
+        let bond_amount_fp = FixedPoint::from(U256::from_dec_str(bond_amount).map_err(|_| {
+            PyErr::new::<PyValueError, _>("Failed to convert bond_amount string to U256")
         })?);
         let open_vault_share_price_fp =
             FixedPoint::from(U256::from_dec_str(open_vault_share_price).map_err(|_| {
@@ -164,19 +164,19 @@ impl HyperdriveState {
             })?);
         let result_fp = self
             .state
-            .calculate_open_short(short_amount_fp, open_vault_share_price_fp)
+            .calculate_open_short(bond_amount_fp, open_vault_share_price_fp)
             .unwrap();
         let result = U256::from(result_fp).to_string();
         Ok(result)
     }
 
-    pub fn calculate_open_short_share_reserves_delta(&self, bond_amount: &str) -> PyResult<String> {
+    pub fn calculate_pool_deltas_after_open_short(&self, bond_amount: &str) -> PyResult<String> {
         let bond_amount_fp = FixedPoint::from(U256::from_dec_str(bond_amount).map_err(|_| {
             PyErr::new::<PyValueError, _>("Failed to convert bond_amount string to U256")
         })?);
         let result_fp = self
             .state
-            .calculate_open_short_share_reserves_delta(bond_amount_fp)
+            .calculate_pool_deltas_after_open_short(bond_amount_fp)
             .unwrap();
         let result = U256::from(result_fp).to_string();
         Ok(result)

--- a/bindings/hyperdrivepy/src/hyperdrive_state_methods.rs
+++ b/bindings/hyperdrivepy/src/hyperdrive_state_methods.rs
@@ -71,9 +71,10 @@ impl HyperdriveState {
         let result_fp = self
             .state
             .calculate_spot_price_after_short(bond_amount_fp, maybe_base_amount_fp)
-            .unwrap();
-        let result = U256::from(result_fp).to_string();
-        Ok(result)
+            .map_err(|_| {
+                PyErr::new::<PyValueError, _>("Failed to calculate spot price after short.")
+            })?;
+        Ok(U256::from(result_fp).to_string())
     }
 
     pub fn calculate_spot_price(&self) -> PyResult<String> {
@@ -164,6 +165,18 @@ impl HyperdriveState {
         let result_fp = self
             .state
             .calculate_open_short(short_amount_fp, open_vault_share_price_fp)
+            .unwrap();
+        let result = U256::from(result_fp).to_string();
+        Ok(result)
+    }
+
+    pub fn calculate_open_short_share_adjustment(&self, bond_amount: &str) -> PyResult<String> {
+        let bond_amount_fp = FixedPoint::from(U256::from_dec_str(bond_amount).map_err(|_| {
+            PyErr::new::<PyValueError, _>("Failed to convert bond_amount string to U256")
+        })?);
+        let result_fp = self
+            .state
+            .calculate_open_short_share_adjustment(bond_amount_fp)
             .unwrap();
         let result = U256::from(result_fp).to_string();
         Ok(result)

--- a/bindings/hyperdrivepy/src/hyperdrive_state_methods.rs
+++ b/bindings/hyperdrivepy/src/hyperdrive_state_methods.rs
@@ -170,13 +170,13 @@ impl HyperdriveState {
         Ok(result)
     }
 
-    pub fn calculate_open_short_share_adjustment(&self, bond_amount: &str) -> PyResult<String> {
+    pub fn calculate_open_short_share_reserves_delta(&self, bond_amount: &str) -> PyResult<String> {
         let bond_amount_fp = FixedPoint::from(U256::from_dec_str(bond_amount).map_err(|_| {
             PyErr::new::<PyValueError, _>("Failed to convert bond_amount string to U256")
         })?);
         let result_fp = self
             .state
-            .calculate_open_short_share_adjustment(bond_amount_fp)
+            .calculate_open_short_share_reserves_delta(bond_amount_fp)
             .unwrap();
         let result = U256::from(result_fp).to_string();
         Ok(result)

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -96,6 +96,23 @@ impl State {
             - payment_factor
     }
 
+    pub fn calculate_open_short_share_adjustment(
+        &self,
+        bond_amount: FixedPoint,
+    ) -> Result<FixedPoint> {
+        let spot_price = self.calculate_spot_price();
+        let curve_fee = self.open_short_curve_fee(bond_amount, spot_price);
+        let gov_curve_fee = self.open_short_governance_fee(bond_amount, spot_price);
+        let short_principal = self.calculate_shares_out_given_bonds_in_down_safe(bond_amount)?;
+        if short_principal.mul_up(self.vault_share_price()) > bond_amount {
+            return Err(eyre!("InsufficientLiquidity: Negative Interest",));
+        }
+        if short_principal < (curve_fee - gov_curve_fee) {
+            return Err(eyre!("Short principal is too low to account for fees",));
+        }
+        Ok(short_principal - (curve_fee - gov_curve_fee))
+    }
+
     /// Calculates the spot price after opening a Hyperdrive short.
     pub fn calculate_spot_price_after_short(
         &self,
@@ -104,12 +121,7 @@ impl State {
     ) -> Result<FixedPoint> {
         let shares_amount = match maybe_base_amount {
             Some(base_amount) => base_amount / self.vault_share_price(),
-            None => {
-                let spot_price = self.calculate_spot_price();
-                self.calculate_short_principal(bond_amount)?
-                    - self.open_short_curve_fee(bond_amount, spot_price)
-                    + self.open_short_governance_fee(bond_amount, spot_price)
-            }
+            None => self.calculate_open_short_share_adjustment(bond_amount)?,
         };
         let mut state: State = self.clone();
         state.info.bond_reserves += bond_amount.into();
@@ -545,6 +557,63 @@ mod tests {
             bob.reset(Default::default());
         }
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fuzz_calculate_spot_price_after_short_defaults() -> Result<()> {
+        let mut rng = thread_rng();
+        let mut num_checks = 0;
+        for _ in 0..*FUZZ_RUNS {
+            // We use a random state but we will ignore any case where a call
+            // fails because we want to test the default behavior when the state
+            // allows all actions.
+            let state = rng.gen::<State>();
+            let checkpoint_exposure = {
+                let value = rng.gen_range(fixed!(0)..=fixed!(10_000_000e18));
+                if rng.gen() {
+                    -I256::try_from(value).unwrap()
+                } else {
+                    I256::try_from(value).unwrap()
+                }
+            };
+            let open_vault_share_price = rng.gen_range(fixed!(0)..=state.vault_share_price());
+            let max_bond_amount = match panic::catch_unwind(|| {
+                state.calculate_max_short(
+                    U256::MAX,
+                    open_vault_share_price,
+                    checkpoint_exposure,
+                    None,
+                    None,
+                )
+            }) {
+                Ok(max_bond_amount) => max_bond_amount,
+                Err(_) => continue,
+            };
+            if max_bond_amount == fixed!(0) {
+                continue;
+            }
+            // Using the default behavior
+            let bond_amount = rng.gen_range(state.minimum_transaction_amount()..=max_bond_amount);
+            let price_with_default = state.calculate_spot_price_after_short(bond_amount, None)?;
+
+            // Using a pre-calculated base amount
+            let base_amount = match state.calculate_open_short_share_adjustment(bond_amount) {
+                Ok(share_amount) => Some(share_amount * state.vault_share_price()),
+                Err(_) => continue,
+            };
+            let price_with_base_amount =
+                state.calculate_spot_price_after_short(bond_amount, base_amount)?;
+
+            // Test equality
+            assert_eq!(
+                price_with_default, price_with_base_amount,
+                "`calculate_spot_price_after_short` is not handling default base_amount correctly."
+            );
+            num_checks += 1
+        }
+        // We want to make sure we didn't `continue` through all possible fuzz states
+        assert!(num_checks > 0);
         Ok(())
     }
 

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -366,7 +366,6 @@ mod tests {
                     state.effective_share_reserves().into(),
                     state.bond_reserves().into(),
                     bond_amount.into(),
-                    // (fixed!(1e18) - state.time_stretch()).into(),
                     state.time_stretch().into(),
                     state.vault_share_price().into(),
                     state.initial_vault_share_price().into(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hyperdrivepy"
-version = "0.14.2"
+version = "0.14.3"
 authors = [
     { name = "Dylan Paiton", email = "dylan@delv.tech" },
     { name = "Matthew Brown", email = "matt@delv.tech" },


### PR DESCRIPTION
# Resolved Issues
No issue

# Description
`calculate_spot_price_after_short` did not correctly compute the share deltas when a `base_amount` was not given. This PR adds a test to demonstrate this as well as a fix.

Part of the process also required adding `calculate_open_short_deltas` and a corresponding test.

Since I was most of the way there, I also added a `preview_open_short` that returns a mutated state after the reserve deltas have been applied.

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed.

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
