### PR TITLE
add fuzz script

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Code Owners
-* @jalextowle @jrhea @mcclurejt @dpaiton @sentilesdal @ryangoree
+* @jalextowle @jrhea @mcclurejt @dpaiton @sentilesdal @ryangoree @slundqui @wakamex

--- a/scripts/list_tests.sh
+++ b/scripts/list_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cargo test -- --list |
+  sed -n '/: test$/p' |
+  sed 's/^ *//;s/: test$//' |
+  sed 's/\([^:]*\)::\([^:]*\)/\1::\2/' |
+  sed 's/ /\\ /g' |
+  grep -v -E '^crates/hyperdrive-wrappers/src/wrappers/'


### PR DESCRIPTION
adds a script that allows you to list all tests in the repo. It also updates codeowners to include @wakamex and @slundqui 