### PR TITLE
Add hyperdrive symlink for hyprdrive-wrappers local development

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1527,6 +1533,7 @@ dependencies = [
 name = "hyperdrive-wrappers"
 version = "0.1.0"
 dependencies = [
+ "dotenv",
  "ethers",
  "ethers-solc",
  "eyre",

--- a/README.md
+++ b/README.md
@@ -79,8 +79,11 @@ symlink the local repository to the `hyperdrive-wrappers` directory:
 ln -s <path-to-local-hyperdrive-clone> crates/hyperdrive-wrappers
 ```
 
-Ensure the `hyperdrive.version` file is updated to point to the correct branch
-if necessary.
+And then in the .env file in hyperdrive-wrappers, add:
+
+```sh
+LOCAL_DEVELOPMENT=true
+```
 
 ## Test
 

--- a/crates/hyperdrive-wrappers/.env.sample
+++ b/crates/hyperdrive-wrappers/.env.sample
@@ -1,0 +1,1 @@
+LOCAL_DEVELOPMENT=true

--- a/crates/hyperdrive-wrappers/.gitignore
+++ b/crates/hyperdrive-wrappers/.gitignore
@@ -1,2 +1,3 @@
 # The hyperdrive repo will be cloned during build
 hyperdrive
+.env

--- a/crates/hyperdrive-wrappers/Cargo.toml
+++ b/crates/hyperdrive-wrappers/Cargo.toml
@@ -24,4 +24,5 @@ ethers = "2.0.8"
 ethers-solc = "2.0.8"
 eyre = "0.6.8"
 heck = "0.4.1"
+dotenv = "0.15.0"
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
# Description
  Adds the ability to set a .env LOCAL_DEVELOPMENT flag so that hyperdrive-wrappers will used a symlinked version of hyperdrive when building the wrappers.  

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed.

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
