### PR TITLE
add `calculate_pool_[deltas/state]_after_open_long`

### DIFF
--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -4,6 +4,13 @@ use fixed_point::FixedPoint;
 use crate::{calculate_rate_given_fixed_price, State, YieldSpace};
 
 impl State {
+    // pub fn preview_open_long
+    //     &self,
+    //     base_amount: FixedPoint,
+    //     maybe_bond_amount: Option<FixedPoint>,
+    // ) -> Result<Self> {
+    // }
+
     /// Calculates the long amount that will be opened for a given base amount.
     ///
     /// The long amount $y(x)$ that a trader will receive is given by:

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -4,13 +4,6 @@ use fixed_point::FixedPoint;
 use crate::{calculate_rate_given_fixed_price, State, YieldSpace};
 
 impl State {
-    // pub fn preview_open_long
-    //     &self,
-    //     base_amount: FixedPoint,
-    //     maybe_bond_amount: Option<FixedPoint>,
-    // ) -> Result<Self> {
-    // }
-
     /// Calculates the long amount that will be opened for a given base amount.
     ///
     /// The long amount $y(x)$ that a trader will receive is given by:
@@ -51,6 +44,36 @@ impl State {
         }
 
         Ok(long_amount - self.open_long_curve_fees(base_amount))
+    }
+
+    /// Calculate an updated pool state after opening a long.
+    ///
+    /// For a given base amount and bond amount, base is converted to
+    /// shares and the reserves are updated such that
+    /// `state.bond_reserves -= bond_amount` and
+    /// `state.share_reserves += base_amount / vault_share_price`.
+    pub fn calculate_pool_state_after_open_long(
+        &self,
+        base_amount: FixedPoint,
+        maybe_bond_amount: Option<FixedPoint>,
+    ) -> Result<Self> {
+        let bond_amount = match maybe_bond_amount {
+            Some(bond_amount) => bond_amount,
+            None => self.calculate_open_long(base_amount)?,
+        };
+        let mut state = self.clone();
+        state.info.bond_reserves -= bond_amount.into();
+        state.info.share_reserves += (base_amount / self.vault_share_price()).into();
+        Ok(state)
+    }
+
+    /// Calculate the share deltas to be applied to the pool after opening a long.
+    pub fn calculate_pool_deltas_after_open_long(
+        &self,
+        base_amount: FixedPoint,
+    ) -> Result<FixedPoint> {
+        let bond_amount = self.calculate_open_long(base_amount)?;
+        Ok(bond_amount)
     }
 
     /// Calculates the spot price after opening a Hyperdrive long.

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -98,8 +98,9 @@ impl State {
 
     /// Calculate an updated pool state after opening a short.
     ///
-    /// For a given bond amount and share amount, the reserves are updated
-    /// such that the `state.bond_reserves += bond_amount` and
+    /// For a given bond amount and share amount,
+    /// the reserves are updated such that
+    /// `state.bond_reserves += bond_amount` and
     /// `state.share_reserves -= share_amount`.
     pub fn calculate_pool_state_after_open_short(
         &self,
@@ -113,7 +114,7 @@ impl State {
         let mut state = self.clone();
         state.info.bond_reserves += bond_amount.into();
         state.info.share_reserves -= shares_delta.into();
-        return Ok(state);
+        Ok(state)
     }
 
     /// Calculate the share deltas to be applied to the pool after opening a short.
@@ -134,7 +135,7 @@ impl State {
         Ok(short_principal - (curve_fee - gov_curve_fee))
     }
 
-    /// Calculates the spot price after opening a Hyperdrive short.
+    /// Calculates the spot price after opening a short.
     pub fn calculate_spot_price_after_short(
         &self,
         bond_amount: FixedPoint,


### PR DESCRIPTION
Adds functions for calculating pool state and pool deltas after opening a long.

The pool deltas function is a mirror of `calculate_open_long` due to the way Hyperdrive works, but I added the function to mirror the short API.