### PR TITLE
Build wheels only on tag releases

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -4,23 +4,15 @@ on:
   push:
     tags:
       - "v*"
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-  detect-changes:
-    uses: ./.github/workflows/check_diff.yml
-    with:
-      pattern: ^bindings/hyperdrivepy/\|^test/\|^crates/\|^lib/\|^target/\|^foundry\.toml$\|^Cargo\.lock$\|^Cargo\.toml$\|^\.github/workflows/build_wheels\.yml$
-
   build-wheels-linux:
     name: build wheels on linux
     runs-on: ubuntu-latest
-    needs: detect-changes
-    if: needs.detect-changes.outputs.changed == 'true'
     steps:
       - name: Checkout hyperdrive-rs
         uses: actions/checkout@v4
@@ -60,8 +52,6 @@ jobs:
   build-wheels-cibw:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    needs: detect-changes
-    if: needs.detect-changes.outputs.changed == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -115,8 +105,6 @@ jobs:
   build-sdist:
     name: build source distribution
     runs-on: ubuntu-latest
-    needs: detect-changes
-    if: needs.detect-changes.outputs.changed == 'true'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Removing building hyperdrivepy wheels in PR, only build and upload in tagged releases
