### PR TITLE
fix fuzz_defaults_calculate_spot_price_after_short

### DIFF
--- a/crates/hyperdrive-math/src/short/fees.rs
+++ b/crates/hyperdrive-math/src/short/fees.rs
@@ -7,7 +7,10 @@ use crate::State;
 impl State {
     /// Calculates the curve fee paid by the trader when they open a short.
     pub fn open_short_curve_fee(&self, bond_amount: FixedPoint) -> FixedPoint {
-        self.curve_fee() * (fixed!(1e18) - self.calculate_spot_price()) * bond_amount
+        // NOTE: Round up to overestimate the curve fee.
+        self.curve_fee()
+            .mul_up(fixed!(1e18) - self.calculate_spot_price())
+            .mul_up(bond_amount)
     }
 
     /// Calculates the governance fee paid by the trader when they open a short.

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -123,8 +123,12 @@ impl State {
         &self,
         bond_amount: FixedPoint,
     ) -> Result<FixedPoint> {
-        let curve_fee = self.open_short_curve_fee(bond_amount);
-        let gov_curve_fee = self.open_short_governance_fee(bond_amount);
+        let curve_fee = self
+            .open_short_curve_fee(bond_amount)
+            .div_up(self.vault_share_price());
+        let gov_curve_fee = self
+            .open_short_governance_fee(bond_amount)
+            .div_up(self.vault_share_price());
         let short_principal = self.calculate_shares_out_given_bonds_in_down_safe(bond_amount)?;
         if short_principal.mul_up(self.vault_share_price()) > bond_amount {
             return Err(eyre!("InsufficientLiquidity: Negative Interest",));


### PR DESCRIPTION
# Resolved Issues

This PR fixes the failing test `fuzz_defaults_calculate_spot_price_after_short()` by ensuring that the fees are returned in units of shares. Additionally, we are now rounding up similar to the smart contracts (when calculating curve fee)
