### PR TITLE
Fix `open_short_curve_fee`

### DIFF
--- a/crates/hyperdrive-math/src/short/fees.rs
+++ b/crates/hyperdrive-math/src/short/fees.rs
@@ -9,13 +9,13 @@ impl State {
     pub fn open_short_curve_fee(&self, bond_amount: FixedPoint) -> FixedPoint {
         // NOTE: Round up to overestimate the curve fee.
         self.curve_fee()
-            .mul_up(fixed!(1e18) - self.calculate_spot_price())
-            .mul_up(bond_amount)
+            .mul_down(fixed!(1e18) - self.calculate_spot_price())
+            .mul_down(bond_amount)
     }
 
     /// Calculates the governance fee paid by the trader when they open a short.
     pub fn open_short_governance_fee(&self, bond_amount: FixedPoint) -> FixedPoint {
-        self.governance_lp_fee() * self.open_short_curve_fee(bond_amount)
+        self.governance_lp_fee().mul_down(self.open_short_curve_fee(bond_amount))
     }
 
     /// Calculates the curve fee paid by shorts for a given bond amount.

--- a/crates/hyperdrive-math/src/short/fees.rs
+++ b/crates/hyperdrive-math/src/short/fees.rs
@@ -15,7 +15,8 @@ impl State {
 
     /// Calculates the governance fee paid by the trader when they open a short.
     pub fn open_short_governance_fee(&self, bond_amount: FixedPoint) -> FixedPoint {
-        self.governance_lp_fee().mul_down(self.open_short_curve_fee(bond_amount))
+        self.governance_lp_fee()
+            .mul_down(self.open_short_curve_fee(bond_amount))
     }
 
     /// Calculates the curve fee paid by shorts for a given bond amount.

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -497,7 +497,6 @@ mod tests {
         chain::TestChain,
         constants::{FAST_FUZZ_RUNS, FUZZ_RUNS},
     };
-    use tracing_test::traced_test;
 
     use super::*;
     use crate::test_utils::agent::HyperdriveMathAgent;
@@ -578,8 +577,6 @@ mod tests {
     }
 
     /// Tests that the absolute max short can be executed on chain.
-    #[ignore]
-    #[traced_test]
     #[tokio::test]
     async fn fuzz_calculate_absolute_max_short_execute() -> Result<()> {
         // Spawn a test chain and create two agents -- Alice and Bob. Alice
@@ -587,12 +584,9 @@ mod tests {
         // the pool. Bob is funded with plenty of capital to ensure we can execute
         // the absolute maximum short.
         let mut rng = thread_rng();
-        let chain = TestChain::new().await?;
-
+        
         for _ in 0..*FUZZ_RUNS {
-            // // Snapshot the chain BEFORE creating any agents.
-            let id = chain.snapshot().await?;
-
+            let chain = TestChain::new().await?;
             let mut alice = chain.alice().await?;
             let mut bob = chain.bob().await?;
             let config = alice.get_config().clone();
@@ -645,15 +639,11 @@ mod tests {
             // for deposit << the global max short number of bonds.
             bob.fund(global_max_short + fixed!(10e18)).await?;
             bob.open_short(global_max_short, None, None).await?;
-
-            // Revert to the snapshot and reset the agent's wallets.
-            chain.revert(id).await?;
         }
 
         Ok(())
     }
 
-    #[traced_test]
     #[tokio::test]
     async fn fuzz_calculate_max_short() -> Result<()> {
         // Spawn a test chain and create two agents -- Alice and Bob. Alice

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -508,7 +508,6 @@ mod tests {
     /// `calculate_max_short`'s functionality. With this in mind, we provide
     /// `calculate_max_short` with a budget of `U256::MAX` to ensure that the two
     /// functions are equivalent.
-    #[ignore]
     #[tokio::test]
     async fn fuzz_calculate_max_short_no_budget() -> Result<()> {
         let chain = TestChain::new().await?;

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -584,7 +584,7 @@ mod tests {
         // the pool. Bob is funded with plenty of capital to ensure we can execute
         // the absolute maximum short.
         let mut rng = thread_rng();
-        
+
         for _ in 0..*FUZZ_RUNS {
             let chain = TestChain::new().await?;
             let mut alice = chain.alice().await?;


### PR DESCRIPTION
# Resolved Issues

Related to #88 

# Description

We were using `mul_up` where the contracts use `mulDown`: https://github.com/delvtech/hyperdrive/blob/33982bba72d861b3b90cb0b4083fec30accb649f/test/utils/HyperdriveUtils.sol#L1362

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed.

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
