### PR TITLE
Fix fuzz max long test

### DIFF
--- a/bindings/hyperdrivepy/src/hyperdrive_state_methods.rs
+++ b/bindings/hyperdrivepy/src/hyperdrive_state_methods.rs
@@ -309,9 +309,12 @@ impl HyperdriveState {
         let checkpoint_exposure_i = I256::from_dec_str(checkpoint_exposure).map_err(|_| {
             PyErr::new::<PyValueError, _>("Failed to convert checkpoint_exposure string to I256")
         })?;
-        let result_fp =
-            self.state
-                .calculate_max_long(budget_fp, checkpoint_exposure_i, maybe_max_iterations);
+        let result_fp = self
+            .state
+            .calculate_max_long(budget_fp, checkpoint_exposure_i, maybe_max_iterations)
+            .map_err(|e| {
+                PyErr::new::<PyValueError, _>(format!("Failed to calculate max long: {}", e))
+            })?;
         let result = U256::from(result_fp).to_string();
         Ok(result)
     }

--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -332,7 +332,6 @@ impl YieldSpace for State {
 
 #[cfg(test)]
 mod tests {
-    use eyre::Result;
     use rand::thread_rng;
 
     use super::*;

--- a/crates/hyperdrive-math/src/long/fees.rs
+++ b/crates/hyperdrive-math/src/long/fees.rs
@@ -15,8 +15,8 @@ impl State {
     /// $$
     pub fn open_long_curve_fee(&self, base_amount: FixedPoint) -> FixedPoint {
         // NOTE: Round up to overestimate the curve fee.
-        (fixed!(1e18).div_up(self.calculate_spot_price()) - fixed!(1e18))
-            .mul_up(self.curve_fee())
+        self.curve_fee()
+            .mul_up(fixed!(1e18).div_up(self.calculate_spot_price()) - fixed!(1e18))
             .mul_up(base_amount)
     }
 
@@ -38,9 +38,9 @@ impl State {
             None => self.open_long_curve_fee(base_amount),
         };
         // NOTE: Round down to underestimate the governance curve fee.
-        self.calculate_spot_price()
-            .mul_down(curve_fee)
+        curve_fee
             .mul_down(self.governance_lp_fee())
+            .mul_down(self.calculate_spot_price())
     }
 
     /// Calculates the curve fee paid when closing longs for a given bond amount.

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -57,9 +57,9 @@ impl State {
             return Ok(fixed!(0));
         }
 
-        // Calculate the maximum long that brings the spot price to 1. If the pool is
-        // solvent after opening this long, then we're done.
-        let (absolute_max_base_amount, absolute_max_bond_amount) = self.absolute_max_long();
+        // Calculate the maximum long that brings the spot price to 1.
+        // If the pool is solvent after opening this long, then we're done.
+        let (absolute_max_base_amount, absolute_max_bond_amount) = self.absolute_max_long()?;
         if self
             .solvency_after_long(
                 absolute_max_base_amount,
@@ -166,17 +166,14 @@ impl State {
                 "Reached absolute max bond amount in `calculate_max_long`."
             ));
         }
-        if max_base_amount >= budget {
-            return Ok(budget);
-        }
 
-        Ok(max_base_amount)
+        Ok(max_base_amount.min(budget))
     }
 
     /// Calculates the largest long that can be opened without buying bonds at a
     /// negative interest rate. This calculation does not take Hyperdrive's
     /// solvency constraints into account and shouldn't be used directly.
-    fn absolute_max_long(&self) -> (FixedPoint, FixedPoint) {
+    fn absolute_max_long(&self) -> Result<(FixedPoint, FixedPoint)> {
         // We are targeting the pool's max spot price of:
         //
         // p_max = (1 - flatFee) / (1 + curveFee * (1 / p_0 - 1) * (1 - flatFee))
@@ -207,19 +204,21 @@ impl State {
         //               ((1 + curveFee * (1 / p_0 - 1) * (1 - flatFee)) / (1 - flatFee)) ** ((1 - t_s) / t_s))
         //           )
         //       ) ** (1 / (1 - t_s))
-        let inner = (self.k_down()
-            / (self
-                .vault_share_price()
-                .div_up(self.initial_vault_share_price())
-                + ((fixed!(1e18)
-                    + self
-                        .curve_fee()
-                        .mul_up(fixed!(1e18).div_up(self.calculate_spot_price()) - fixed!(1e18))
-                        .mul_up(fixed!(1e18) - self.flat_fee()))
-                .div_up(fixed!(1e18) - self.flat_fee()))
-                .pow((fixed!(1e18) - self.time_stretch()) / (self.time_stretch()))))
-        .pow(fixed!(1e18) / (fixed!(1e18) - self.time_stretch()));
-        let target_share_reserves = inner / self.initial_vault_share_price();
+        let inner = self
+            .k_down()
+            .div_down(
+                self.vault_share_price()
+                    .div_up(self.initial_vault_share_price())
+                    + ((fixed!(1e18)
+                        + self
+                            .curve_fee()
+                            .mul_up(fixed!(1e18).div_up(self.calculate_spot_price()) - fixed!(1e18))
+                            .mul_up(fixed!(1e18) - self.flat_fee()))
+                    .div_up(fixed!(1e18) - self.flat_fee()))
+                    .pow((fixed!(1e18) - self.time_stretch()).div_down(self.time_stretch())),
+            )
+            .pow(fixed!(1e18).div_down(fixed!(1e18) - self.time_stretch()));
+        let target_share_reserves = inner.div_down(self.initial_vault_share_price());
 
         // Now that we have the target share reserves, we can calculate the
         // target bond reserves using the formula:
@@ -229,36 +228,33 @@ impl State {
         // `inner` as defined above is `mu * z_t` so we calculate y_t as
         //
         // y_t = inner * ((1 + curveFee * (1 / p_0 - 1) * (1 - flatFee)) / (1 - flatFee)) ** (1 / t_s)
-        let target_bond_reserves = inner
-            * ((fixed!(1e18)
-                + self.curve_fee()
-                    * (fixed!(1e18) / (self.calculate_spot_price()) - fixed!(1e18))
-                    * (fixed!(1e18) - self.flat_fee()))
-                / (fixed!(1e18) - self.flat_fee()))
-            .pow(fixed!(1e18).div_up(self.time_stretch()));
+        let fee_adjustment = self.curve_fee()
+            * (fixed!(1e18) / self.calculate_spot_price() - fixed!(1e18))
+            * (fixed!(1e18) - self.flat_fee());
+        let target_bond_reserves = ((fixed!(1e18) + fee_adjustment)
+            / (fixed!(1e18) - self.flat_fee()))
+        .pow(fixed!(1e18).div_up(self.time_stretch()))
+            * inner;
 
-        // The absolute max base amount is given by:
-        //
-
-        // Here, the target share reserves may be smaller than the effective share reserves.
-        // Instead of throwing a panic error in fixed point, we catch this here and throw a
-        // descriptive panic.
-        // TODO this likely should throw an err.
+        // Catch if the target share reserves are smaller than the effective share reserves.
         let effective_share_reserves = self.effective_share_reserves();
         if target_share_reserves < effective_share_reserves {
-            panic!("target share reserves less than effective share reserves");
+            return Err(eyre!(
+                "target share reserves less than effective share reserves"
+            ));
         }
 
+        // The absolute max base amount is given by:
+        // absolute_max_base_amount = (z_t - z_e) * c
         let absolute_max_base_amount =
             (target_share_reserves - effective_share_reserves) * self.vault_share_price();
 
         // The absolute max bond amount is given by:
-        //
-        // absoluteMaxBondAmount = (y - y_t) - c(x)
+        // absolute_max_bond_amount = (y - y_t) - Phi_c(absolute_max_base_amount)
         let absolute_max_bond_amount = (self.bond_reserves() - target_bond_reserves)
             - self.open_long_curve_fee(absolute_max_base_amount);
 
-        (absolute_max_base_amount, absolute_max_bond_amount)
+        Ok((absolute_max_base_amount, absolute_max_bond_amount))
     }
 
     /// Calculates an initial guess of the max long that can be opened. This is a
@@ -545,7 +541,7 @@ mod tests {
                 .await
             {
                 Ok((expected_base_amount, expected_bond_amount)) => {
-                    let (actual_base_amount, actual_bond_amount) = actual.unwrap();
+                    let (actual_base_amount, actual_bond_amount) = actual.unwrap().unwrap();
                     assert_eq!(actual_base_amount, FixedPoint::from(expected_base_amount));
                     assert_eq!(actual_bond_amount, FixedPoint::from(expected_bond_amount));
                 }
@@ -631,7 +627,7 @@ mod tests {
                         FixedPoint::from(expected_base_amount)
                     );
                 }
-                Err(_) => assert!(actual.is_err()),
+                Err(_) => assert!(actual.is_err() || actual.unwrap().is_err()),
             }
 
             // Reset chain snapshot.

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -572,11 +572,6 @@ mod tests {
             // Gen a random state.
             let mut state = rng.gen::<State>();
 
-            // Make sure maturity times are in the future.
-            let current_block_timestamp = alice.now().await?;
-            state.info.long_average_maturity_time += current_block_timestamp;
-            state.info.short_average_maturity_time += current_block_timestamp;
-
             // Generate a random checkpoint exposure.
             let checkpoint_exposure = {
                 let value = rng.gen_range(fixed!(0)..=FixedPoint::from(I256::MAX));

--- a/crates/hyperdrive-math/src/long/targeted.rs
+++ b/crates/hyperdrive-math/src/long/targeted.rs
@@ -355,12 +355,10 @@ mod tests {
     use fixed_point_macros::uint256;
     use rand::{thread_rng, Rng};
     use test_utils::{chain::TestChain, constants::FUZZ_RUNS};
-    use tracing_test::traced_test;
 
     use super::*;
     use crate::test_utils::agent::HyperdriveMathAgent;
 
-    #[traced_test]
     #[tokio::test]
     async fn test_calculate_targeted_long_with_budget() -> Result<()> {
         // Spawn a test chain and create two agents -- Alice and Bob.

--- a/crates/hyperdrive-math/src/long/targeted.rs
+++ b/crates/hyperdrive-math/src/long/targeted.rs
@@ -400,7 +400,7 @@ mod tests {
                 let max_long =
                     bob.get_state()
                         .await?
-                        .calculate_max_long(U256::MAX, I256::from(0), None);
+                        .calculate_max_long(U256::MAX, I256::from(0), None)?;
                 let long_amount =
                     (max_long / fixed!(100e18)).max(config.minimum_transaction_amount.into());
                 bob.fund(long_amount + budget).await?;

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -286,7 +286,6 @@ mod tests {
         chain::{ChainClient, TestChain},
         constants::{BOB, FAST_FUZZ_RUNS, FUZZ_RUNS},
     };
-    use tracing_test::traced_test;
 
     use super::*;
     use crate::test_utils::agent::HyperdriveMathAgent;
@@ -504,7 +503,6 @@ mod tests {
     /// This test empirically tests `short_deposit_derivative` by calling
     /// `calculate_open_short` at two points and comparing the empirical result
     /// with the output of `short_deposit_derivative`.
-    #[traced_test]
     #[tokio::test]
     async fn fuzz_short_deposit_derivative() -> Result<()> {
         let mut rng = thread_rng();

--- a/crates/hyperdrive-math/src/test_utils/agent.rs
+++ b/crates/hyperdrive-math/src/test_utils/agent.rs
@@ -122,7 +122,13 @@ impl HyperdriveMathAgent for Agent<ChainClient<LocalWallet>, ChaCha8Rng> {
             .hyperdrive()
             .get_checkpoint_exposure(state.to_checkpoint(self.now().await?))
             .await?;
-        Ok(state.calculate_max_long(self.wallet.base, checkpoint_exposure, maybe_max_iterations))
+        Ok(
+            state.calculate_max_long(
+                self.wallet.base,
+                checkpoint_exposure,
+                maybe_max_iterations,
+            )?,
+        )
     }
 
     /// Gets the long that moves the fixed rate to a target value.

--- a/crates/hyperdrive-math/src/utils.rs
+++ b/crates/hyperdrive-math/src/utils.rs
@@ -198,7 +198,10 @@ mod tests {
             let max_long = match panic::catch_unwind(|| {
                 state.calculate_max_long(U256::MAX, checkpoint_exposure, None)
             }) {
-                Ok(max_long) => max_long,
+                Ok(max_long) => match max_long {
+                    Ok(max_long) => max_long,
+                    Err(_) => continue,
+                },
                 Err(_) => continue, // Don't finish this fuzz iteration.
             };
             let min_rate = state.calculate_spot_rate_after_long(max_long, None)?;

--- a/crates/hyperdrive-wrappers/src/lib.rs
+++ b/crates/hyperdrive-wrappers/src/lib.rs
@@ -6,7 +6,7 @@ pub mod wrappers;
 pub mod linked_factory {
     use std::sync::Arc;
 
-    use ethers::{abi::Abi, prelude::*, types::Bytes, utils::hex};
+    use ethers::{abi::Abi, prelude::*, utils::hex};
     use ethers_solc::utils::library_hash_placeholder;
 
     /// Creates a contract factory with the given ABI and bytecode, linking the given libraries


### PR DESCRIPTION
# Resolved Issues
Partially resolves these two:
https://github.com/delvtech/hyperdrive-rs/issues/88
https://github.com/delvtech/hyperdrive-rs/issues/45

# Description
The fee rounding behavior was adjusted recently to more closely match solidity, but the order of operations was not exactly the same. This caused an occasional slight variation in output (usually off by 1e1), that compounded in situations where we were iteratively assessing fees such as `max_long`. In that case, the error would grow to as much as 1e5.

During my effort to find this bug I
- modified some math to use the e.g. `.mul_down` syntax instead of `*` where it was sufficiently complicated to require this to easily pattern match against Solidity.
- modified `calculate_max_long` to return errors instead of panic. This makes checks in the tests ugly, but that is a temporary problem until we purge the panics all-together (https://github.com/delvtech/hyperdrive-rs/issues/20)
- purged the use of `traced` and `trace_test` which is helpful for debugging but was not actively being used and can slow down tests.

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed.

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
