### PR TITLE
increase tolerance for test_calculate_implied_rate

### DIFF
--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -208,7 +208,7 @@ impl State {
     /// \begin{align}
     /// TPY &= (1 + \frac{APR}{f})^{d \cdot f} \\
     /// &= (1 + APY)^{d} - 1
-    /// \end{align}make
+    /// \end{align}
     /// $$
     pub fn calculate_implied_rate(
         &self,
@@ -703,7 +703,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_calculate_implied_rate() -> Result<()> {
-        let tolerance = int256!(1e14);
+        let tolerance = int256!(1e15);
 
         // Spawn a test chain with two agents.
         let mut rng = thread_rng();


### PR DESCRIPTION
# Resolved Issues
Fixes #107 by increasing test tolerance

# Description
The values used for fuzzing will take the error up to about 3.1e14, specifically when `implied_rate` is in the thousands of percentage points (particularly when variable rate is 50x-100x larger than fixed rate). 

This error likely happens because the underlying MockYieldSource uses the set rate as an APR (yield accrues as `1 + r * t` on stateful transactions), so on continuous compounding it works out to a higher APY, while the calc always treats it as an APY. The test only does a few transactions and then advances time until maturity, so the difference should be minimal, but it's still blown up when the rates are too far apart.

Since this is a helper function used to estimate a number that isn't fed into any other calcs, we've decided it's safe to just increase the tolerance.

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed.

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
