### PR TITLE
update `calc_open_short` to match solidity

### DIFF
--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -29,6 +29,23 @@ impl State {
     /// s = z - \tfrac{exposure}{c} - z_min
     /// $$
     pub fn calculate_solvency(&self) -> FixedPoint {
+        println!(
+            "long::calculate_solvency::share_reserves {:#?}",
+            self.share_reserves()
+        );
+        println!(
+            "long::calculate_solvency::long_exposure {:#?}",
+            self.long_exposure()
+        );
+        println!(
+            "long::calculate_solvency::vault_share_price {:#?}",
+            self.vault_share_price()
+        );
+        println!(
+            "long::calculate_solvency::minimum_share_reserves {:#?}",
+            self.minimum_share_reserves()
+        );
+
         self.share_reserves()
             - self.long_exposure() / self.vault_share_price()
             - self.minimum_share_reserves()

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -120,79 +120,14 @@ impl State {
 
 #[cfg(test)]
 mod tests {
-    use ethers::{signers::LocalWallet, types::U256};
-    use fixed_point::{fixed, uint256};
-    use hyperdrive_test_utils::{
-        agent::Agent,
-        chain::{ChainClient, TestChain},
-        constants::FUZZ_RUNS,
-    };
+    use fixed_point::fixed;
+    use hyperdrive_test_utils::{chain::TestChain, constants::FUZZ_RUNS};
     use hyperdrive_wrappers::wrappers::ihyperdrive::Options;
     use rand::{thread_rng, Rng, SeedableRng};
     use rand_chacha::ChaCha8Rng;
 
     use super::*;
-    use crate::test_utils::agent::HyperdriveMathAgent;
-
-    /// Executes random trades throughout a Hyperdrive term.
-    async fn preamble(
-        rng: &mut ChaCha8Rng,
-        alice: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
-        bob: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
-        celine: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
-        fixed_rate: FixedPoint,
-    ) -> Result<()> {
-        // Fund the agent accounts and initialize the pool.
-        alice
-            .fund(rng.gen_range(fixed!(1_000e18)..=fixed!(500_000_000e18)))
-            .await?;
-        bob.fund(rng.gen_range(fixed!(1_000e18)..=fixed!(500_000_000e18)))
-            .await?;
-        celine
-            .fund(rng.gen_range(fixed!(1_000e18)..=fixed!(500_000_000e18)))
-            .await?;
-
-        // Alice initializes the pool.
-        alice.initialize(fixed_rate, alice.base(), None).await?;
-
-        // Advance the time for over a term and make trades in some of the checkpoints.
-        let mut time_remaining = alice.get_config().position_duration;
-        while time_remaining > uint256!(0) {
-            // Bob opens a long.
-            let discount = rng.gen_range(fixed!(0.1e18)..=fixed!(0.5e18));
-            let long_amount =
-                rng.gen_range(fixed!(1e12)..=bob.calculate_max_long(None).await? * discount);
-            bob.open_long(long_amount, None, None).await?;
-
-            // Celine opens a short.
-            let discount = rng.gen_range(fixed!(0.1e18)..=fixed!(0.5e18));
-            let min_short =
-                FixedPoint::from(alice.get_state().await?.config.minimum_transaction_amount);
-            let max_short = celine.calculate_max_short(None).await? * discount;
-            let short_amount = rng.gen_range(min_short..=max_short);
-            celine.open_short(short_amount, None, None).await?;
-
-            // Advance the time and mint all of the intermediate checkpoints.
-            let multiplier = rng.gen_range(fixed!(5e18)..=fixed!(50e18));
-            let delta = FixedPoint::from(time_remaining)
-                .min(FixedPoint::from(alice.get_config().checkpoint_duration) * multiplier);
-            time_remaining -= U256::from(delta);
-            alice
-                .advance_time(
-                    fixed!(0), // TODO: Use a real rate.
-                    delta,
-                )
-                .await?;
-        }
-
-        // Mint a checkpoint to close any matured positions from the first checkpoint
-        // of trading.
-        alice
-            .checkpoint(alice.latest_checkpoint().await?, uint256!(0), None)
-            .await?;
-
-        Ok(())
-    }
+    use crate::test_utils::{agent::HyperdriveMathAgent, preamble::preamble};
 
     #[tokio::test]
     async fn fuzz_calculate_spot_price_after_long() -> Result<()> {

--- a/crates/hyperdrive-math/src/short/close.rs
+++ b/crates/hyperdrive-math/src/short/close.rs
@@ -59,19 +59,28 @@ impl State {
     /// Calculates the proceeds in shares of closing a short position. This
     /// takes into account the trading profits, the interest that was
     /// earned by the short, the flat fee the short pays, and the amount of
-    /// margin that was released by closing the short. The math for the
-    /// short's proceeds in base is given by:
+    /// margin that was released by closing the short. The adjusted value in
+    /// shares that underlies the bonds is given by:
     ///
     /// $$
-    /// proceeds = (\frac{c1}{c_0}
+    /// P_\text{adj} = (\frac{c1}{c_0 \cdot c}
     /// + \text{\phi_f}) \cdot \frac{\Delta y}{c}
-    /// - dz
     /// $$
     ///
-    /// We convert the proceeds to shares by dividing by the current vault
-    /// share price. In the event that the interest is negative and
-    /// outweighs the trading profits and margin released, the short's
-    /// proceeds are marked to zero.
+    /// and the short proceeds are given by:
+    ///
+    /// $$
+    /// proceeds =
+    /// \begin{cases}
+    ///     P_\text{adj} - dz
+    ///       & \text{if } P_{\text{adj}} > dz \\
+    ///     0,              & \text{otherwise}
+    /// \end{cases}
+    /// $$
+    ///
+    /// where $dz$ is the pool share adjustment. In the event that the interest
+    /// is negative and outweighs the trading profits and margin released,
+    /// the short's proceeds are marked to zero.
     pub fn calculate_short_proceeds_up(
         &self,
         bond_amount: FixedPoint,
@@ -112,19 +121,28 @@ impl State {
     /// Calculates the proceeds in shares of closing a short position. This
     /// takes into account the trading profits, the interest that was
     /// earned by the short, the flat fee the short pays, and the amount of
-    /// margin that was released by closing the short. The math for the
-    /// short's proceeds in base is given by:
+    /// margin that was released by closing the short. The adjusted value in
+    /// shares that underlies the bonds is given by:
     ///
     /// $$
-    /// proceeds = (\frac{c1}{c_0 \cdot c}
+    /// P_\text{adj} = (\frac{c1}{c_0 \cdot c}
     /// + \text{\phi_f}) \cdot \frac{\Delta y}{c}
-    /// - dz
     /// $$
     ///
-    /// We convert the proceeds to shares by dividing by the current vault
-    /// share price. In the event that the interest is negative and
-    /// outweighs the trading profits and margin released, the short's
-    /// proceeds are marked to zero.
+    /// and the short proceeds are given by:
+    ///
+    /// $$
+    /// proceeds =
+    /// \begin{cases}
+    ///     P_\text{adj} - dz
+    ///       & \text{if } P_{\text{adj}} > dz \\
+    ///     0,              & \text{otherwise}
+    /// \end{cases}
+    /// $$
+    ///
+    /// where $dz$ is the pool share adjustment. In the event that the interest
+    /// is negative and outweighs the trading profits and margin released,
+    /// the short's proceeds are marked to zero.
     fn calculate_short_proceeds_down(
         &self,
         bond_amount: FixedPoint,

--- a/crates/hyperdrive-math/src/short/close.rs
+++ b/crates/hyperdrive-math/src/short/close.rs
@@ -105,6 +105,10 @@ impl State {
         // We increase the total value by the flat fee amount, because it is
         // included in the total amount of capital underlying the short.
         total_value += bond_amount.mul_div_up(self.flat_fee(), self.vault_share_price());
+        println!(
+            "calculate_short_proceeds_up::total_value {:#?}",
+            total_value
+        );
 
         // If the interest is more negative than the trading profits and margin
         // released, then the short proceeds are marked to zero. Otherwise, we

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -786,7 +786,8 @@ mod tests {
             // calculation is performed and the transaction is submitted.
             let slippage_tolerance = fixed!(0.0001e18); // 0.01%
             let max_short = bob.calculate_max_short(Some(slippage_tolerance)).await?;
-            bob.open_short(max_short, None, None).await?;
+            bob.open_short(max_short, Some(fixed!(0.01e18)), None)
+                .await?;
 
             // Bob used a slippage tolerance of 0.01%, which means
             // that the max short is always consuming at least 99.99% of
@@ -805,7 +806,7 @@ mod tests {
                 max_short
             );
 
-            // Revert to the snapshot and reset the agent's wallets.
+            // Revert to the snapshot and reset the agents' wallets.
             chain.revert(id).await?;
             alice.reset(Default::default()).await?;
             bob.reset(Default::default()).await?;

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -175,10 +175,8 @@ impl State {
             // Iteratively update max_bond_amount via newton's method.
             let derivative = self.short_deposit_derivative(
                 max_bond_amount,
-                spot_price,
                 open_vault_share_price,
-                self.vault_share_price().max(open_vault_share_price),
-                self.vault_share_price(),
+                Some(spot_price),
             )?;
             if deposit < target_budget {
                 max_bond_amount += (target_budget - deposit) / derivative

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -173,7 +173,7 @@ impl State {
             }
 
             // Iteratively update max_bond_amount via newton's method.
-            let derivative = self.short_deposit_derivative(
+            let derivative = self.calculate_open_short_derivative(
                 max_bond_amount,
                 open_vault_share_price,
                 Some(spot_price),

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -173,10 +173,12 @@ impl State {
             }
 
             // Iteratively update max_bond_amount via newton's method.
-            let derivative = self.calculate_open_short_derivative(
+            let derivative = self.short_deposit_derivative(
                 max_bond_amount,
                 spot_price,
                 open_vault_share_price,
+                self.vault_share_price().max(open_vault_share_price),
+                self.vault_share_price(),
             )?;
             if deposit < target_budget {
                 max_bond_amount += (target_budget - deposit) / derivative

--- a/crates/hyperdrive-math/src/test_utils.rs
+++ b/crates/hyperdrive-math/src/test_utils.rs
@@ -1,3 +1,4 @@
 #[cfg(test)]
 pub mod agent;
 mod integration_tests;
+pub mod preamble;

--- a/crates/hyperdrive-math/src/test_utils/preamble.rs
+++ b/crates/hyperdrive-math/src/test_utils/preamble.rs
@@ -1,0 +1,97 @@
+use std::panic;
+
+use ethers::{signers::LocalWallet, types::U256};
+use eyre::Result;
+use fixed_point::{fixed, uint256, FixedPoint};
+use hyperdrive_test_utils::{agent::Agent, chain::ChainClient};
+use rand::Rng;
+use rand_chacha::ChaCha8Rng;
+
+use crate::test_utils::agent::HyperdriveMathAgent;
+
+/// Executes random trades throughout a Hyperdrive term.
+///
+/// This fn initializes a Hyperdrive pool and does random trades
+/// to force the pool into a random state.
+pub async fn preamble(
+    rng: &mut ChaCha8Rng,
+    alice: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
+    bob: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
+    celine: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
+    fixed_rate: FixedPoint,
+) -> Result<()> {
+    // Fund the agent accounts and initialize the pool.
+    alice
+        .fund(rng.gen_range(fixed!(1_000e18)..=fixed!(500_000_000e18)))
+        .await?;
+    bob.fund(rng.gen_range(fixed!(1_000e18)..=fixed!(500_000_000e18)))
+        .await?;
+    celine
+        .fund(rng.gen_range(fixed!(1_000e18)..=fixed!(500_000_000e18)))
+        .await?;
+
+    // Alice initializes the pool.
+    alice.initialize(fixed_rate, alice.base(), None).await?;
+
+    // Advance the time for over a term and make trades in some of the checkpoints.
+    let mut time_remaining = alice.get_config().position_duration;
+    while time_remaining > uint256!(0) {
+        let mut state = alice.get_state().await?;
+        let min_txn = FixedPoint::from(state.config.minimum_transaction_amount);
+
+        // Bob opens a long.
+        let mut max_long = fixed!(1e29); // 100B max
+        let mut success = false;
+        let mut long_amount = rng.gen_range(min_txn..=max_long);
+        while !success {
+            match panic::catch_unwind(|| state.calculate_open_long(long_amount)) {
+                Ok(long_result_no_panic) => match long_result_no_panic {
+                    Ok(_) => success = true,
+                    Err(_) => max_long /= fixed!(10e18),
+                },
+                Err(_) => max_long /= fixed!(10e18),
+            };
+            long_amount = rng.gen_range(min_txn..=max_long);
+        }
+        bob.open_long(long_amount, None, None).await?;
+        state = alice.get_state().await?;
+
+        // Celine opens a short.
+        let mut max_short = fixed!(1e29); // 100B max
+        let mut success = false;
+        let mut short_amount = rng.gen_range(min_txn..=max_short);
+        while !success {
+            match panic::catch_unwind(|| {
+                state.calculate_open_short(short_amount, state.vault_share_price())
+            }) {
+                Ok(short_result_no_panic) => match short_result_no_panic {
+                    Ok(_) => success = true,
+                    Err(_) => max_short /= fixed!(10e18),
+                },
+                Err(_) => max_short /= fixed!(10e18),
+            };
+            short_amount = rng.gen_range(min_txn..=max_short);
+        }
+        celine.open_short(short_amount, None, None).await?;
+
+        // Advance the time and mint all of the intermediate checkpoints.
+        let multiplier = rng.gen_range(fixed!(5e18)..=fixed!(50e18));
+        let delta = FixedPoint::from(time_remaining)
+            .min(FixedPoint::from(alice.get_config().checkpoint_duration) * multiplier);
+        time_remaining -= U256::from(delta);
+        alice
+            .advance_time(
+                fixed!(0), // TODO: Use a real rate.
+                delta,
+            )
+            .await?;
+    }
+
+    // Mint a checkpoint to close any matured positions from the first checkpoint
+    // of trading.
+    alice
+        .checkpoint(alice.latest_checkpoint().await?, uint256!(0), None)
+        .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
# Resolved Issues
https://github.com/delvtech/hyperdrive-rs/issues/29
https://github.com/delvtech/hyperdrive-rs/issues/121

# Description
This PR updates the Rust open short and derivative implementations to more closely match Solidity.

## Lower tolerances on tests 🎉 
- After the fix, I was able to completely remove the error tolerance on `fuzz_calc_open_short`.
- I also updated the epsilon & tolerance values for the `fuzz_short_deposit_derivative` and `fuzz_short_principal_derivative` tests. I use a larger epsilon and smaller tolerance, which I think is what we prefer (more distant points should match linearity assumptions better due to the lack of monotonicity coming from `pow`).

## Increased tolerances on tests 😭 
- I had to increase error tolerance for `fuzz_calculate_max_short_no_budget` from 1e12 to 1e16. I compared the rust & solidity implementations, but they're too different from each other to find any bugs by pattern matching. I'm not sure what is going on here, and would suggest we open a new issue to investigate. (more on this below)
- I was hoping that this PR would allow me to reduce the additional bond amount in `fuzz_error_open_short_max_txn_amount` (per [this comment](https://github.com/delvtech/hyperdrive-rs/issues/29#issuecomment-2133992696)), but could not (it is still 100M). This is probably related to lingering issues with calculating the max short.
- I had initially thought this PR fixed `fuzz_calculate_max_short`, but I think the more likely scenario is the test wasn't set up to consistently fail for it's condition. I modified the test in my last commit and now it is consistently passing.


## (relatively) Inconsequential updates
- I updated some of the derivative tests to use an [equivalent, but simpler method](https://en.wikipedia.org/wiki/Numerical_differentiation) for numerical differentiation that only applies the epsilon once and therefore makes the distance between points easier to understand from the `empirical_derivative_epsilon` parameter. I also changed the tolerance check to be `<=` instead of `<` for the same reason.
- I removed the use of `calc_max_short` in the preamble & open short tests. While on working this PR I was getting frustrated because the open short tests were failing due to errors in max short. This is a better setup in general, so that our tests behave more like unit tests that are easier to debug than integration tests.
- I renamed `long_amount_derivative` to `calculate_open_long_derivative` and `short_deposit_derivative` to `calculate_open_short_derivative`.
- I moved some arguments out of fn signatures and instead use `state` member variables. This is a departure from Solidity but (imo) justified because the Rust fns are all implemented on the `state` struct. The preferred pattern (and what we do elsewhere) is to update state and call the fn instead of passing different values as fn args.

## Important items to check
- My changes to the short deposit derivative and calc open short were not algebraic -- I believe my function is entirely different from what was there. My guess is calc open short now matches solidity, but the derivative does not. I think it's worth comparing this against solidity to make sure there aren't errors in the solidity implementation of the derivative. It could explain the next point:
- The error in `fuzz_calculate_max_short_no_budget` might be due to a difference in `max_short_guess` or an error in the solidity short derivative fn. I still think this is best investigated in a follow-up issue, but I'm noting it here as a clue for the future.

## Math outline
The below formulation follows the logic outlined in `HyperdriveShort.sol`. I made some slight changes to variable names and ordering of presentation.

![image](https://github.com/delvtech/hyperdrive-rs/assets/153468/ecd63280-93cc-4738-85b9-d4f71e342f31)
![image](https://github.com/delvtech/hyperdrive-rs/assets/153468/a67ae754-1842-421b-bb5d-668f083a2154)
![image](https://github.com/delvtech/hyperdrive-rs/assets/153468/7f174e74-88bd-4b3f-a75a-319833a8aa00)