### PR TITLE
Don't rebuild hyperdrive-wrappers if no solidity files changed.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,6 +1078,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,12 +1552,14 @@ dependencies = [
  "ethers",
  "ethers-solc",
  "eyre",
+ "filetime",
  "heck",
  "lazy_static",
  "rand",
  "serde",
  "serde_json",
  "tokio",
+ "walkdir",
 ]
 
 [[package]]

--- a/crates/hyperdrive-wrappers/Cargo.toml
+++ b/crates/hyperdrive-wrappers/Cargo.toml
@@ -22,10 +22,12 @@ tokio = { version = "1", features = ["full"] }
 [build-dependencies]
 
 # External dependencies
+dotenv = "0.15.0"
 ethers = "2.0.11"
 eyre = "0.6.8"
+filetime = "0.2"
 heck = "0.4.1"
-dotenv = "0.15.0"
-tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.116"
+tokio = { version = "1", features = ["full"] }
+walkdir = "2"

--- a/crates/hyperdrive-wrappers/build.rs
+++ b/crates/hyperdrive-wrappers/build.rs
@@ -75,65 +75,13 @@ fn main() -> Result<()> {
     // Get the root directory of the project.
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
 
-    // Load the hyperdrive version to use from the hyperdrive.version file.
-    let version_file = root.join("hyperdrive.version");
-    let git_ref = read_to_string(version_file)?.trim().to_string();
-
-    // See if we are doing local development to skip re-loading the hyperdrive repo.
-    let local_development = match env::var("LOCAL_DEVELOPMENT") {
-        Ok(local_development) => local_development == "true",
-        _ => false,
-    };
-
-    // Clone the hyperdrive repository if it doesn't exist.
     let hyperdrive_dir = root.join("hyperdrive");
-    if !local_development {
-        if hyperdrive_dir.exists() {
-            checkout_branch(&git_ref, &hyperdrive_dir)?;
-        } else {
-            clone_repo(HYPERDRIVE_URL, &git_ref, &hyperdrive_dir)?;
-        }
-    }
 
-    // Path to the directory containing Solidity files.
-    let solidity_dir = hyperdrive_dir.join("contracts");
+    // Conditionally reload the hyperdrive repo.
+    load_hyperdrive_repo(root, &hyperdrive_dir)?;
 
-    // Find all Solidity files.
-    let solidity_files: Vec<PathBuf> = WalkDir::new(&solidity_dir)
-        .into_iter()
-        .filter_map(|entry| {
-            let entry = entry.ok()?;
-            if entry.path().extension()? == "sol" {
-                Some(entry.path().to_path_buf())
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    // Get the latest modification time of Solidity files.
-    let solidity_latest_mod_time = solidity_files
-        .iter()
-        .map(|path| FileTime::from_last_modification_time(&fs::metadata(path).unwrap()))
-        .max()
-        .unwrap_or_else(|| FileTime::from_system_time(std::time::SystemTime::UNIX_EPOCH));
-
-    // Path to the directory where generated Rust files are placed.
-    let generated_dir = root.join("src/wrappers");
-
-    // Get the latest modification time of the generated Rust files.
-    let output_latest_mod_time = fs::read_dir(&generated_dir)?
-        .filter_map(|entry| entry.ok())
-        .map(|entry| FileTime::from_last_modification_time(&fs::metadata(entry.path()).unwrap()))
-        .max();
-
-    // Check if we need to run the build process.
-    let need_to_build = match output_latest_mod_time {
-        Some(output_mod_time) => output_mod_time < solidity_latest_mod_time,
-        None => true,
-    };
-
-    if !need_to_build {
+    // Only rebuild if solidity files have changed.
+    if !need_to_build(&hyperdrive_dir, root)? {
         println!("No changes detected in Solidity files, skipping build process.");
         return Ok(());
     }
@@ -264,6 +212,52 @@ impl<M: ::ethers::providers::Middleware> {name}<M> {{
     }
 
     Ok(())
+}
+
+fn need_to_build(hyperdrive_dir: &PathBuf, root: &Path) -> Result<bool, eyre::Error> {
+    let solidity_dir = hyperdrive_dir.join("contracts");
+    let solidity_files: Vec<PathBuf> = WalkDir::new(&solidity_dir)
+        .into_iter()
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            if entry.path().extension()? == "sol" {
+                Some(entry.path().to_path_buf())
+            } else {
+                None
+            }
+        })
+        .collect();
+    let solidity_latest_mod_time = solidity_files
+        .iter()
+        .map(|path| FileTime::from_last_modification_time(&fs::metadata(path).unwrap()))
+        .max()
+        .unwrap_or_else(|| FileTime::from_system_time(std::time::SystemTime::UNIX_EPOCH));
+    let generated_dir = root.join("src/wrappers");
+    let output_latest_mod_time = fs::read_dir(&generated_dir)?
+        .filter_map(|entry| entry.ok())
+        .map(|entry| FileTime::from_last_modification_time(&fs::metadata(entry.path()).unwrap()))
+        .max();
+    let need_to_build = match output_latest_mod_time {
+        Some(output_mod_time) => output_mod_time < solidity_latest_mod_time,
+        None => true,
+    };
+    Ok(need_to_build)
+}
+
+fn load_hyperdrive_repo(root: &Path, hyperdrive_dir: &PathBuf) -> Result<(), eyre::Error> {
+    let version_file = root.join("hyperdrive.version");
+    let git_ref = read_to_string(version_file)?.trim().to_string();
+    let local_development = match env::var("LOCAL_DEVELOPMENT") {
+        Ok(local_development) => local_development == "true",
+        _ => false,
+    };
+    Ok(if !local_development {
+        if hyperdrive_dir.exists() {
+            checkout_branch(&git_ref, hyperdrive_dir)?;
+        } else {
+            clone_repo(HYPERDRIVE_URL, &git_ref, hyperdrive_dir)?;
+        }
+    })
 }
 
 struct ArtifactLibs {


### PR DESCRIPTION
# Resolved Issues
n/a

# Description
Building hyperdrive-wrappers takes a long time and happens way too often during local development and testing.  We don't need to rebuild these if no solidity files have changed.  On top of this, vscode is breaking because its watching for changes and rebuilding way too much.  This fixes both of these issues.

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed.

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
