### PR TITLE
fix calculate_implied_rate to exclude the backpaid interest from the cost basis

### DIFF
--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -222,7 +222,9 @@ impl State {
         variable_apy: FixedPoint,
     ) -> Result<I256> {
         let full_base_paid = self.calculate_open_short(bond_amount, open_vault_share_price)?;
-        let backpaid_interest = bond_amount.mul_down(self.vault_share_price() - open_vault_share_price);
+        let backpaid_interest = bond_amount
+            .mul_div_down(self.vault_share_price(), open_vault_share_price)
+            - bond_amount;
         let base_paid = full_base_paid - backpaid_interest;
         let tpy =
             (fixed!(1e18) + variable_apy).pow(self.annualized_position_duration())? - fixed!(1e18);

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -210,13 +210,20 @@ impl State {
     /// &= (1 + APY)^{d} - 1
     /// \end{align}
     /// $$
+    ///
+    /// We use the TPY to figure out the base proceeds, and calculate the rate of
+    /// return based on the short's opening cost. Since shorts must backpay the
+    /// variable interest accrued since the last checkpoint, we subtract that from
+    /// the opening cost, as they get it back upon closing the short.
     pub fn calculate_implied_rate(
         &self,
         bond_amount: FixedPoint,
         open_vault_share_price: FixedPoint,
         variable_apy: FixedPoint,
     ) -> Result<I256> {
-        let base_paid = self.calculate_open_short(bond_amount, open_vault_share_price)?;
+        let full_base_paid = self.calculate_open_short(bond_amount, open_vault_share_price)?;
+        let backpaid_interest = bond_amount.mul_down(self.vault_share_price() - open_vault_share_price);
+        let base_paid = full_base_paid - backpaid_interest;
         let tpy =
             (fixed!(1e18) + variable_apy).pow(self.annualized_position_duration())? - fixed!(1e18);
         let base_proceeds = bond_amount * tpy;


### PR DESCRIPTION
# Resolved Issues
#119 Implied rate (Short ROI) is negative in some cases where fixed > variable

# Description
This excludes the short's backpaid interest from implied_rate calc

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed.

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
