### PR TITLE
add `calculate_short_proceeds_up` 

### DIFF
--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -293,12 +293,9 @@ mod tests {
     use hyperdrive_test_utils::{
         agent::Agent,
         chain::{ChainClient, TestChain},
-        constants::{BOB, FAST_FUZZ_RUNS, FUZZ_RUNS},
+        constants::{FAST_FUZZ_RUNS, FUZZ_RUNS},
     };
-    use hyperdrive_wrappers::wrappers::{
-        ihyperdrive::{Checkpoint, Options},
-        mock_erc4626::MockERC4626,
-    };
+    use hyperdrive_wrappers::wrappers::ihyperdrive::{Checkpoint, Options};
     use rand::{thread_rng, Rng, SeedableRng};
     use rand_chacha::ChaCha8Rng;
 


### PR DESCRIPTION
# Resolved Issues
Partially addresses https://github.com/delvtech/hyperdrive-rs/issues/29 and https://github.com/delvtech/hyperdrive-rs/issues/21

# Description
These are steps towards implementing a parity implementation of open short as well as targeted short.
- Add a function to calc short proceeds & round up, which is used in the Open Short flow.
- Modifies calculate short proceeds down to look more like the up version.

Since these functions are implemented on State, we preferentially use State member variables (e.g. `vault_share_price`) instead of passing arguments.

The short proceeds is given by:

$$
P_{\text{short}}(\Delta y) = \tfrac{\Delta y \cdot c_{1}}{c_{0} \cdot c} + \tfrac{\Delta y}{c} \cdot \phi_{f} - \Delta z(\Delta y)
$$