### PR TITLE
Dry up test preamble; code cleanup

### DIFF
--- a/crates/fixed-point/src/lib.rs
+++ b/crates/fixed-point/src/lib.rs
@@ -521,6 +521,12 @@ mod tests {
     }
 
     #[test]
+    fn test_sub_failure() {
+        // Ensure that subtraction producing negative numbers fails.
+        assert!(panic::catch_unwind(|| fixed!(1e18) - fixed!(2e18)).is_err());
+    }
+
+    #[test]
     fn test_mul_div_down_failure() {
         // Ensure that division by zero fails.
         assert!(panic::catch_unwind(|| fixed!(1e18).mul_div_down(fixed!(1e18), 0.into())).is_err());

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -66,6 +66,7 @@ impl State {
                 checkpoint_exposure,
             )
             .is_ok()
+            && absolute_max_base_amount >= self.minimum_transaction_amount()
         {
             return Ok(absolute_max_base_amount.min(budget));
         }

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -132,67 +132,9 @@ mod tests {
     use rand_chacha::ChaCha8Rng;
 
     use super::*;
-    use crate::test_utils::agent::HyperdriveMathAgent;
-
-    /// Executes random trades throughout a Hyperdrive term.
-    async fn preamble(
-        rng: &mut ChaCha8Rng,
-        alice: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
-        bob: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
-        celine: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
-        fixed_rate: FixedPoint,
-    ) -> Result<()> {
-        // Fund the agent accounts and initialize the pool.
-        alice
-            .fund(rng.gen_range(fixed!(1_000e18)..=fixed!(500_000_000e18)))
-            .await?;
-        bob.fund(rng.gen_range(fixed!(1_000e18)..=fixed!(500_000_000e18)))
-            .await?;
-        celine
-            .fund(rng.gen_range(fixed!(1_000e18)..=fixed!(500_000_000e18)))
-            .await?;
-
-        // Alice initializes the pool.
-        alice.initialize(fixed_rate, alice.base(), None).await?;
-
-        // Advance the time for over a term and make trades in some of the checkpoints.
-        let mut time_remaining = alice.get_config().position_duration;
-        while time_remaining > uint256!(0) {
-            // Bob opens a long.
-            let discount = rng.gen_range(fixed!(0.1e18)..=fixed!(0.5e18));
-            let long_amount =
-                rng.gen_range(fixed!(1e12)..=bob.calculate_max_long(None).await? * discount);
-            bob.open_long(long_amount, None, None).await?;
-
-            // Celine opens a short.
-            let discount = rng.gen_range(fixed!(0.1e18)..=fixed!(0.5e18));
-            let min_short =
-                FixedPoint::from(alice.get_state().await?.config.minimum_transaction_amount);
-            let max_short = celine.calculate_max_short(None).await? * discount;
-            let short_amount = rng.gen_range(min_short..=max_short);
-            celine.open_short(short_amount, None, None).await?;
-
-            // Advance the time and mint all of the intermediate checkpoints.
-            let multiplier = rng.gen_range(fixed!(5e18)..=fixed!(50e18));
-            let delta = FixedPoint::from(time_remaining)
-                .min(FixedPoint::from(alice.get_config().checkpoint_duration) * multiplier);
-            time_remaining -= U256::from(delta);
-            alice
-                .advance_time(
-                    fixed!(0), // TODO: Use a real rate.
-                    delta,
-                )
-                .await?;
-        }
-
-        // Mint a checkpoint to close any matured positions from the first checkpoint
-        // of trading.
-        alice
-            .checkpoint(alice.latest_checkpoint().await?, uint256!(0), None)
-            .await?;
-
-        Ok(())
-    }
+    use crate::test_utils::{
+        agent::HyperdriveMathAgent, preamble::initialize_pool_with_random_state,
+    };
 
     #[tokio::test]
     async fn fuzz_calculate_spot_price_after_long() -> Result<()> {
@@ -411,8 +353,7 @@ mod tests {
             let id = chain.snapshot().await?;
 
             // Run the preamble.
-            let fixed_rate = fixed!(0.05e18);
-            preamble(&mut rng, &mut alice, &mut bob, &mut celine, fixed_rate).await?;
+            initialize_pool_with_random_state(&mut rng, &mut alice, &mut bob, &mut celine).await?;
 
             // Get state and trade details.
             let state = alice.get_state().await?;

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -362,7 +362,8 @@ mod tests {
             let rust_bonds = state.calculate_open_long(base_amount);
 
             // Fund a little extra to allow for of slippage.
-            bob.fund(base_amount + fixed!(10e18)).await?;
+            bob.fund(base_amount + base_amount * fixed!(0.001e18))
+                .await?;
             match bob
                 .hyperdrive()
                 .open_long(

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -120,13 +120,11 @@ impl State {
 
 #[cfg(test)]
 mod tests {
-    use ethers::{signers::LocalWallet, types::U256};
-    use fixed_point::{fixed, uint256};
-    use hyperdrive_test_utils::{
-        agent::Agent,
-        chain::{ChainClient, TestChain},
-        constants::FUZZ_RUNS,
-    };
+    use std::panic;
+
+    use ethers::types::{I256, U256};
+    use fixed_point::fixed;
+    use hyperdrive_test_utils::{chain::TestChain, constants::FUZZ_RUNS};
     use hyperdrive_wrappers::wrappers::ihyperdrive::Options;
     use rand::{thread_rng, Rng, SeedableRng};
     use rand_chacha::ChaCha8Rng;
@@ -291,8 +289,7 @@ mod tests {
                 }
             };
             let max_iterations = 7;
-            let open_vault_share_price = rng.gen_range(fixed!(0)..=state.vault_share_price());
-            // TODO: We should use calculate_absolute_max_short here because that is what we are testing.
+            // TODO: We should use calculate_absolute_max_long here because that is what we are testing.
             // We need to catch panics because of FixedPoint overflows & underflows.
             let max_trade = panic::catch_unwind(|| {
                 state.calculate_max_long(U256::MAX, checkpoint_exposure, Some(max_iterations))

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -364,6 +364,8 @@ mod tests {
             // Compare the open short call output against calculate_open_long.
             let rust_bonds = state.calculate_open_long(base_amount);
 
+            // Fund a little extra to allow for of slippage.
+            bob.fund(base_amount + fixed!(10e18)).await?;
             match bob
                 .hyperdrive()
                 .open_long(

--- a/crates/hyperdrive-math/src/lp/remove.rs
+++ b/crates/hyperdrive-math/src/lp/remove.rs
@@ -25,9 +25,6 @@ impl State {
             return Err(eyre!("Minimum transaction amount not met"));
         }
 
-        // Get vault share price and proceed without checkpoint.
-        let vault_share_price = self.vault_share_price();
-
         // Burn the LP's shares.
         let mut state = self.clone();
         state.info.lp_total_supply -= lp_shares.into();

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -292,11 +292,10 @@ impl State {
 mod tests {
     use std::panic;
 
-    use ethers::{signers::LocalWallet, types::U256};
-    use fixed_point::{fixed, int256, uint256};
+    use ethers::types::U256;
+    use fixed_point::{fixed, int256};
     use hyperdrive_test_utils::{
-        agent::Agent,
-        chain::{ChainClient, TestChain},
+        chain::TestChain,
         constants::{FAST_FUZZ_RUNS, FUZZ_RUNS},
     };
     use hyperdrive_wrappers::wrappers::ihyperdrive::{Checkpoint, Options};

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -827,7 +827,7 @@ mod tests {
 
     #[tokio::test]
     pub async fn fuzz_sol_calc_open_short() -> Result<()> {
-        let tolerance = fixed!(1e9);
+        let tolerance = fixed!(10e18);
 
         // Set up a random number generator. We use ChaCha8Rng with a randomly
         // generated seed, which makes it easy to reproduce test failures given
@@ -854,9 +854,9 @@ mod tests {
             // Get state and trade details.
             let state = alice.get_state().await?;
             let Checkpoint {
-                vault_share_price: open_vault_share_price,
                 weighted_spot_price: _,
                 last_weighted_spot_price_update_time: _,
+                vault_share_price: open_vault_share_price,
             } = alice
                 .get_checkpoint(state.to_checkpoint(alice.now().await?))
                 .await?;

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -304,67 +304,9 @@ mod tests {
     use rand_chacha::ChaCha8Rng;
 
     use super::*;
-    use crate::test_utils::agent::HyperdriveMathAgent;
-
-    /// Executes random trades throughout a Hyperdrive term.
-    async fn preamble(
-        rng: &mut ChaCha8Rng,
-        alice: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
-        bob: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
-        celine: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
-        fixed_rate: FixedPoint,
-    ) -> Result<()> {
-        // Fund the agent accounts and initialize the pool.
-        alice
-            .fund(rng.gen_range(fixed!(1_000e18)..=fixed!(500_000_000e18)))
-            .await?;
-        bob.fund(rng.gen_range(fixed!(1_000e18)..=fixed!(500_000_000e18)))
-            .await?;
-        celine
-            .fund(rng.gen_range(fixed!(1_000e18)..=fixed!(500_000_000e18)))
-            .await?;
-
-        // Alice initializes the pool.
-        alice.initialize(fixed_rate, alice.base(), None).await?;
-
-        // Advance the time for over a term and make trades in some of the checkpoints.
-        let mut time_remaining = alice.get_config().position_duration;
-        while time_remaining > uint256!(0) {
-            // Bob opens a long.
-            let discount = rng.gen_range(fixed!(0.1e18)..=fixed!(0.5e18));
-            let long_amount =
-                rng.gen_range(fixed!(1e12)..=bob.calculate_max_long(None).await? * discount);
-            bob.open_long(long_amount, None, None).await?;
-
-            // Celine opens a short.
-            let discount = rng.gen_range(fixed!(0.1e18)..=fixed!(0.5e18));
-            let min_short =
-                FixedPoint::from(alice.get_state().await?.config.minimum_transaction_amount);
-            let max_short = celine.calculate_max_short(None).await? * discount;
-            let short_amount = rng.gen_range(min_short..=max_short);
-            celine.open_short(short_amount, None, None).await?;
-
-            // Advance the time and mint all of the intermediate checkpoints.
-            let multiplier = rng.gen_range(fixed!(5e18)..=fixed!(50e18));
-            let delta = FixedPoint::from(time_remaining)
-                .min(FixedPoint::from(alice.get_config().checkpoint_duration) * multiplier);
-            time_remaining -= U256::from(delta);
-            alice
-                .advance_time(
-                    fixed!(0), // TODO: Use a real rate.
-                    delta,
-                )
-                .await?;
-        }
-
-        // Mint a checkpoint to close any matured positions from the first checkpoint
-        // of trading.
-        alice
-            .checkpoint(alice.latest_checkpoint().await?, uint256!(0), None)
-            .await?;
-
-        Ok(())
-    }
+    use crate::test_utils::{
+        agent::HyperdriveMathAgent, preamble::initialize_pool_with_random_state,
+    };
 
     #[tokio::test]
     async fn test_calculate_pool_deltas_after_open_short() -> Result<()> {
@@ -908,8 +850,7 @@ mod tests {
             let id = chain.snapshot().await?;
 
             // Run the preamble.
-            let fixed_rate = fixed!(0.05e18);
-            preamble(&mut rng, &mut alice, &mut bob, &mut celine, fixed_rate).await?;
+            initialize_pool_with_random_state(&mut rng, &mut alice, &mut bob, &mut celine).await?;
 
             // Get state and trade details.
             let state = alice.get_state().await?;

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -870,6 +870,8 @@ mod tests {
             // Compare the open short call output against calculate_open_short.
             let rust_base = state.calculate_open_short(bond_amount, open_vault_share_price.into());
 
+            // The base required should always be less than the short amount.
+            celine.fund(bond_amount).await?;
             match celine
                 .hyperdrive()
                 .open_short(

--- a/crates/hyperdrive-math/src/test_utils.rs
+++ b/crates/hyperdrive-math/src/test_utils.rs
@@ -1,3 +1,4 @@
 #[cfg(test)]
 pub mod agent;
 mod integration_tests;
+pub mod preamble;

--- a/crates/hyperdrive-math/src/test_utils/integration_tests.rs
+++ b/crates/hyperdrive-math/src/test_utils/integration_tests.rs
@@ -13,65 +13,9 @@ mod tests {
     use rand::{thread_rng, Rng, SeedableRng};
     use rand_chacha::ChaCha8Rng;
 
-    use crate::test_utils::agent::HyperdriveMathAgent;
-
-    /// Executes random trades throughout a Hyperdrive term.
-    async fn preamble(
-        rng: &mut ChaCha8Rng,
-        alice: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
-        bob: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
-        celine: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
-        fixed_rate: FixedPoint,
-    ) -> Result<()> {
-        // Fund the agent accounts and initialize the pool.
-        alice
-            .fund(rng.gen_range(fixed!(1_000e18)..=fixed!(500_000_000e18)))
-            .await?;
-        bob.fund(rng.gen_range(fixed!(1_000e18)..=fixed!(500_000_000e18)))
-            .await?;
-        celine
-            .fund(rng.gen_range(fixed!(1_000e18)..=fixed!(500_000_000e18)))
-            .await?;
-
-        // Alice initializes the pool.
-        alice.initialize(fixed_rate, alice.base(), None).await?;
-
-        // Advance the time for over a term and make trades in some of the checkpoints.
-        let mut time_remaining = alice.get_config().position_duration;
-        while time_remaining > uint256!(0) {
-            // Bob opens a long.
-            let discount = rng.gen_range(fixed!(0.1e18)..=fixed!(0.5e18));
-            let long_amount =
-                rng.gen_range(fixed!(1e12)..=bob.calculate_max_long(None).await? * discount);
-            bob.open_long(long_amount, None, None).await?;
-
-            // Celine opens a short.
-            let discount = rng.gen_range(fixed!(0.1e18)..=fixed!(0.5e18));
-            let bond_amount =
-                rng.gen_range(fixed!(1e12)..=celine.calculate_max_short(None).await? * discount);
-            celine.open_short(bond_amount, None, None).await?;
-
-            // Advance the time and mint all of the intermediate checkpoints.
-            let multiplier = rng.gen_range(fixed!(5e18)..=fixed!(50e18));
-            let delta = FixedPoint::from(time_remaining)
-                .min(FixedPoint::from(alice.get_config().checkpoint_duration) * multiplier);
-            time_remaining -= U256::from(delta);
-            alice
-                .advance_time(
-                    fixed!(0), // TODO: Use a real rate.
-                    delta,
-                )
-                .await?;
-        }
-
-        // Mint a checkpoint to close any matured positions from the first checkpoint
-        // of trading.
-        alice
-            .checkpoint(alice.latest_checkpoint().await?, uint256!(0), None)
-            .await?;
-
-        Ok(())
-    }
+    use crate::test_utils::{
+        agent::HyperdriveMathAgent, preamble::initialize_pool_with_random_state,
+    };
 
     // TODO: Unignore after we add the logic to apply checkpoints prior to computing
     // the max long.
@@ -98,8 +42,7 @@ mod tests {
             let id = chain.snapshot().await?;
 
             // Run the preamble.
-            let fixed_rate = fixed!(0.05e18);
-            preamble(&mut rng, &mut alice, &mut bob, &mut celine, fixed_rate).await?;
+            initialize_pool_with_random_state(&mut rng, &mut alice, &mut bob, &mut celine).await?;
 
             // Celine opens a max short. Despite the trading that happened before this,
             // we expect Celine to open the max short on the pool or consume almost all
@@ -177,8 +120,7 @@ mod tests {
             let id = chain.snapshot().await?;
 
             // Run the preamble.
-            let fixed_rate = fixed!(0.05e18);
-            preamble(&mut rng, &mut alice, &mut bob, &mut celine, fixed_rate).await?;
+            initialize_pool_with_random_state(&mut rng, &mut alice, &mut bob, &mut celine).await?;
 
             // One of three things should be true after opening the long:
             //
@@ -196,7 +138,8 @@ mod tests {
             let is_max_price = max_spot_price - spot_price_after_long < fixed!(1e15);
             let is_solvency_consumed = {
                 let state = bob.get_state().await?;
-                let error_tolerance = fixed!(1_000e18).mul_div_down(fixed_rate, fixed!(0.1e18));
+                let error_tolerance =
+                    fixed!(1_000e18).mul_div_down(state.calculate_spot_rate()?, fixed!(0.1e18));
                 state.calculate_solvency() < error_tolerance
             };
             let is_budget_consumed = {

--- a/crates/hyperdrive-math/src/test_utils/integration_tests.rs
+++ b/crates/hyperdrive-math/src/test_utils/integration_tests.rs
@@ -1,14 +1,10 @@
 #[cfg(test)]
 mod tests {
 
-    use ethers::{signers::LocalWallet, types::U256};
+    use ethers::types::U256;
     use eyre::Result;
-    use fixed_point::{fixed, uint256, FixedPoint};
-    use hyperdrive_test_utils::{
-        agent::Agent,
-        chain::{ChainClient, TestChain},
-        constants::FUZZ_RUNS,
-    };
+    use fixed_point::fixed;
+    use hyperdrive_test_utils::{chain::TestChain, constants::FUZZ_RUNS};
     use hyperdrive_wrappers::wrappers::ihyperdrive::Checkpoint;
     use rand::{thread_rng, Rng, SeedableRng};
     use rand_chacha::ChaCha8Rng;

--- a/crates/hyperdrive-math/src/test_utils/preamble.rs
+++ b/crates/hyperdrive-math/src/test_utils/preamble.rs
@@ -1,0 +1,301 @@
+use std::panic;
+
+use ethers::{
+    signers::LocalWallet,
+    types::{I256, U128, U256},
+};
+use eyre::{eyre, Result};
+use fixed_point::{fixed, uint256, FixedPoint};
+use hyperdrive_test_utils::{agent::Agent, chain::ChainClient};
+use hyperdrive_wrappers::wrappers::ihyperdrive::Checkpoint;
+use rand::Rng;
+use rand_chacha::ChaCha8Rng;
+
+use crate::{test_utils::agent::HyperdriveMathAgent, State};
+
+/// Executes random trades throughout a Hyperdrive term.
+///
+/// This fn initializes a Hyperdrive pool and does random trades
+/// to force the pool into a random state.
+pub async fn initialize_pool_with_random_state(
+    rng: &mut ChaCha8Rng,
+    alice: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
+    bob: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
+    celine: &mut Agent<ChainClient<LocalWallet>, ChaCha8Rng>,
+) -> Result<()> {
+    // Get random pool liquidity & fixed rate.
+    let pool_initial_contribution = rng.gen_range(fixed!(1_000e18)..=fixed!(1_000_000_000e18));
+    let fixed_rate = rng.gen_range(fixed!(0.01e18)..=fixed!(0.1e18));
+
+    // Alice initializes the pool.
+    alice.fund(pool_initial_contribution).await?;
+    alice
+        .initialize(fixed_rate, pool_initial_contribution, None)
+        .await?;
+
+    // Advance the time for over a term and make trades in some of the checkpoints.
+    let mut time_remaining = alice.get_config().position_duration;
+    while time_remaining > uint256!(0) {
+        let mut state = alice.get_state().await?;
+        let min_txn = state.minimum_transaction_amount();
+
+        // Bob opens a long.
+        let max_long = get_max_long(state, None)?;
+        let long_amount = rng.gen_range(min_txn..=max_long);
+        bob.fund(long_amount + fixed!(10e18)).await?; // Fund a little extra for slippage.
+        bob.open_long(long_amount, None, None).await?;
+
+        // Celine opens a short.
+        state = alice.get_state().await?;
+
+        // Get the current checkpoint exposure.
+        let Checkpoint {
+            vault_share_price: open_vault_share_price,
+            weighted_spot_price: _,
+            last_weighted_spot_price_update_time: _,
+        } = alice
+            .get_checkpoint(state.to_checkpoint(alice.now().await?))
+            .await?;
+        let checkpoint_exposure = alice
+            .get_checkpoint_exposure(state.to_checkpoint(alice.now().await?))
+            .await?;
+        let max_short = get_max_short(state, checkpoint_exposure, None)?;
+        let short_amount = rng.gen_range(min_txn..=max_short);
+        celine.fund(short_amount + fixed!(10e18)).await?; // Fund a little extra for slippage.
+        celine.open_short(short_amount, None, None).await?;
+
+        // Advance the time and mint all of the intermediate checkpoints.
+        let multiplier = rng.gen_range(fixed!(10e18)..=fixed!(100e18));
+        let delta = FixedPoint::from(time_remaining)
+            .min(FixedPoint::from(alice.get_config().checkpoint_duration) * multiplier);
+        time_remaining -= U256::from(delta);
+        let variable_rate = rng.gen_range(fixed!(0.01e18)..=fixed!(0.1e18));
+        alice.advance_time(variable_rate, delta).await?;
+    }
+
+    // Mint a checkpoint to close any matured positions.
+    alice
+        .checkpoint(alice.latest_checkpoint().await?, uint256!(0), None)
+        .await?;
+
+    // Add some liquidity again to make sure future bots can make trades.
+    let liquidity_amount = rng.gen_range(fixed!(1_000e18)..=fixed!(100_000_000e18));
+    alice.fund(liquidity_amount).await?;
+    alice.add_liquidity(liquidity_amount, None).await?;
+
+    Ok(())
+}
+
+/// Conservative and safe estimate of the maximum long.
+fn get_max_long(state: State, maybe_max_num_tries: Option<usize>) -> Result<FixedPoint> {
+    let max_num_tries = maybe_max_num_tries.unwrap_or(10);
+    let checkpoint_exposure = I256::from(0);
+
+    // We need a guaranteed method of picking a good upper-bound, even if underlying functions aren't working.
+    // So we will first attempt to use `calculate_max_long` and then we will double check and reduce
+    // the max if necessary.
+    let mut max_long = match panic::catch_unwind(|| {
+        state.calculate_max_long(U256::from(U128::MAX), checkpoint_exposure, Some(3))
+    }) {
+        Ok(max_long_no_panic) => match max_long_no_panic {
+            Ok(max_long_no_err) => max_long_no_err,
+            Err(_) => state.bond_reserves() * state.calculate_spot_price()? * fixed!(10e18),
+        },
+        Err(_) => state.bond_reserves() * state.calculate_spot_price()? * fixed!(10e18),
+    };
+
+    let mut num_tries = 0;
+    let mut success = false;
+    while !success {
+        max_long = match panic::catch_unwind(|| state.calculate_open_long(max_long)) {
+            Ok(long_result_no_panic) => match long_result_no_panic {
+                Ok(_) => {
+                    success = true;
+                    max_long
+                }
+                Err(_) => max_long / fixed!(10e18),
+            },
+            Err(_) => max_long / fixed!(10e18),
+        };
+        if max_long < state.minimum_transaction_amount() {
+            return Err(eyre!(
+                "max_long={} was less than minimum_transaction_amount={}",
+                max_long,
+                state.minimum_transaction_amount()
+            ));
+        }
+        num_tries += 1;
+        if num_tries > max_num_tries {
+            return Err(eyre!(
+                "Failed to find a max long. Last attempted value was {}",
+                max_long,
+            ));
+        }
+    }
+    Ok(max_long)
+}
+
+/// Conservative and safe estimate of the maximum short.
+fn get_max_short(
+    state: State,
+    checkpoint_exposure: I256,
+    maybe_max_num_tries: Option<usize>,
+) -> Result<FixedPoint> {
+    let max_num_tries = maybe_max_num_tries.unwrap_or(10);
+
+    // We linearly interpolate between the current spot price and the minimum
+    // price that the pool can support. This is a conservative estimate of
+    // the short's realized price.
+    let conservative_price = {
+        // We estimate the minimum price that short will pay by a
+        // weighted average of the spot price and the minimum possible
+        // spot price the pool can quote. We choose the weights so that this
+        // is an underestimate of the worst case realized price.
+        let spot_price = state.calculate_spot_price()?;
+        let min_price = state.calculate_min_price()?;
+
+        // Calculate the linear interpolation.
+        let base_reserves = state.vault_share_price() * state.share_reserves();
+        let weight = fixed!(1e18).pow(fixed!(1e18) - state.time_stretch())?;
+        spot_price * (fixed!(1e18) - weight) + min_price * weight
+    };
+
+    // Compute the max short.
+    let mut max_short = match panic::catch_unwind(|| {
+        state.calculate_max_short(
+            U256::from(U128::MAX),
+            state.vault_share_price(),
+            checkpoint_exposure,
+            Some(conservative_price),
+            Some(3),
+        )
+    }) {
+        Ok(max_short_no_panic) => match max_short_no_panic {
+            Ok(max_short) => max_short,
+            Err(_) => state.share_reserves() / state.vault_share_price() * fixed!(10e18),
+        },
+        Err(_) => state.share_reserves() / state.vault_share_price() * fixed!(10e18),
+    };
+    let mut num_tries = 0;
+    let mut success = false;
+    while !success {
+        max_short = match panic::catch_unwind(|| {
+            state.calculate_open_short(max_short, state.vault_share_price())
+        }) {
+            Ok(short_result_no_panic) => match short_result_no_panic {
+                Ok(_) => {
+                    success = true;
+                    max_short
+                }
+                Err(_) => max_short / fixed!(10e18),
+            },
+            Err(_) => max_short / fixed!(10e18),
+        };
+        if max_short < state.minimum_transaction_amount() {
+            return Err(eyre!(
+                "max_short={} was less than minimum_transaction_amount={}.",
+                max_short,
+                state.minimum_transaction_amount()
+            ));
+        }
+        num_tries += 1;
+        if num_tries > max_num_tries {
+            return Err(eyre!(
+                "Failed to find a max short. Last attempted value was {}",
+                max_short,
+            ));
+        }
+    }
+    Ok(max_short)
+}
+
+#[cfg(test)]
+mod tests {
+    use fixed_point::fixed;
+    use hyperdrive_test_utils::{chain::TestChain, constants::FUZZ_RUNS};
+    use rand::{thread_rng, Rng, SeedableRng};
+    use rand_chacha::ChaCha8Rng;
+
+    use super::*;
+    use crate::test_utils::agent::HyperdriveMathAgent;
+
+    #[tokio::test]
+    async fn fuzz_max_long_after_preamble() -> Result<()> {
+        // Set up a random number generator. We use ChaCha8Rng with a randomly
+        // generated seed, which makes it easy to reproduce test failures given
+        // the seed.
+        let mut rng = {
+            let mut rng = thread_rng();
+            let seed = rng.gen();
+            ChaCha8Rng::seed_from_u64(seed)
+        };
+
+        // Initialize the test chain & agents.
+        let chain = TestChain::new().await?;
+        let mut alice = chain.alice().await?;
+        let mut bob = chain.bob().await?;
+        let mut celine = chain.celine().await?;
+
+        for _ in 0..*FUZZ_RUNS {
+            // Snapshot the chain.
+            let id = chain.snapshot().await?;
+
+            // Run the preamble.
+            initialize_pool_with_random_state(&mut rng, &mut alice, &mut bob, &mut celine).await?;
+
+            // Get state and trade details, then open the max long.
+            let state = alice.get_state().await?;
+            let max_long = bob.calculate_max_long(None).await?;
+            assert!(max_long >= state.minimum_transaction_amount());
+            bob.fund(max_long + fixed!(10e18)).await?;
+            bob.open_long(max_long, None, None).await?;
+
+            // Reset the chain & agents.
+            chain.revert(id).await?;
+            alice.reset(Default::default()).await?;
+            bob.reset(Default::default()).await?;
+            celine.reset(Default::default()).await?;
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fuzz_max_short_after_preamble() -> Result<()> {
+        // Set up a random number generator. We use ChaCha8Rng with a randomly
+        // generated seed, which makes it easy to reproduce test failures given
+        // the seed.
+        let mut rng = {
+            let mut rng = thread_rng();
+            let seed = rng.gen();
+            ChaCha8Rng::seed_from_u64(seed)
+        };
+
+        // Initialize the test chain & agents.
+        let chain = TestChain::new().await?;
+        let mut alice = chain.alice().await?;
+        let mut bob = chain.bob().await?;
+        let mut celine = chain.celine().await?;
+
+        for _ in 0..*FUZZ_RUNS {
+            // Snapshot the chain.
+            let id = chain.snapshot().await?;
+
+            // Run the preamble.
+            initialize_pool_with_random_state(&mut rng, &mut alice, &mut bob, &mut celine).await?;
+
+            // Get state and trade details, then open the max short.
+            let state = alice.get_state().await?;
+            let max_short = bob.calculate_max_short(None).await?;
+            assert!(max_short >= state.minimum_transaction_amount());
+            bob.fund(max_short + fixed!(10e18)).await?;
+            bob.open_short(max_short, None, None).await?;
+
+            // Reset the chain & agents.
+            chain.revert(id).await?;
+            alice.reset(Default::default()).await?;
+            bob.reset(Default::default()).await?;
+            celine.reset(Default::default()).await?;
+        }
+        Ok(())
+    }
+}

--- a/crates/hyperdrive-math/src/test_utils/preamble.rs
+++ b/crates/hyperdrive-math/src/test_utils/preamble.rs
@@ -7,7 +7,6 @@ use ethers::{
 use eyre::{eyre, Result};
 use fixed_point::{fixed, uint256, FixedPoint};
 use hyperdrive_test_utils::{agent::Agent, chain::ChainClient};
-use hyperdrive_wrappers::wrappers::ihyperdrive::Checkpoint;
 use rand::Rng;
 use rand_chacha::ChaCha8Rng;
 
@@ -49,13 +48,6 @@ pub async fn initialize_pool_with_random_state(
         state = alice.get_state().await?;
 
         // Get the current checkpoint exposure.
-        let Checkpoint {
-            vault_share_price: open_vault_share_price,
-            weighted_spot_price: _,
-            last_weighted_spot_price_update_time: _,
-        } = alice
-            .get_checkpoint(state.to_checkpoint(alice.now().await?))
-            .await?;
         let checkpoint_exposure = alice
             .get_checkpoint_exposure(state.to_checkpoint(alice.now().await?))
             .await?;
@@ -155,7 +147,6 @@ fn get_max_short(
         let min_price = state.calculate_min_price()?;
 
         // Calculate the linear interpolation.
-        let base_reserves = state.vault_share_price() * state.share_reserves();
         let weight = fixed!(1e18).pow(fixed!(1e18) - state.time_stretch())?;
         spot_price * (fixed!(1e18) - weight) + min_price * weight
     };

--- a/crates/hyperdrive-math/src/yield_space.rs
+++ b/crates/hyperdrive-math/src/yield_space.rs
@@ -33,6 +33,9 @@ pub trait YieldSpace {
     /// Core ///
 
     fn calculate_spot_price(&self) -> Result<FixedPoint> {
+        if self.y() <= fixed!(0) {
+            return Err(eyre!("expected y={} > 0", self.y()));
+        }
         ((self.mu() * self.ze()?) / self.y()).pow(self.t())
     }
 
@@ -55,6 +58,9 @@ pub trait YieldSpace {
         // NOTE: We round _y up to make the rhs of the equation larger.
         //
         // k - (c / µ) * (µ * (ze + dz))^(1 - t))^(1 / (1 - t)))
+        if k < ze {
+            return Err(eyre!("expected k={} >= ze={}", k, ze));
+        }
         let mut y = k - ze;
         if y >= fixed!(1e18) {
             // Rounding up the exponent results in a larger result.
@@ -65,6 +71,9 @@ pub trait YieldSpace {
         }
 
         // Δy = y - (k - (c / µ) * (µ * (z + dz))^(1 - t))^(1 / (1 - t)))
+        if self.y() < y {
+            return Err(eyre!("expected y={} >= delta_y={}", self.y(), y));
+        }
         Ok(self.y() - y)
     }
 

--- a/crates/hyperdrive-test-utils/src/agent.rs
+++ b/crates/hyperdrive-test-utils/src/agent.rs
@@ -455,6 +455,11 @@ impl Agent<ChainClient<LocalWallet>, ChaCha8Rng> {
             .send()
             .await?;
 
+        // HACK: Sleep for a few ms to give anvil some time to catch up. We
+        // shouldn't need this, but anvil gets stuck in timeout loops when
+        // these calls are made in quick succession with retries.
+        sleep(Duration::from_millis(50)).await;
+
         // Increase the base balance in the wallet.
         self.wallet.base += amount;
 

--- a/crates/hyperdrive-wrappers/build.rs
+++ b/crates/hyperdrive-wrappers/build.rs
@@ -1,10 +1,7 @@
 use std::{
     collections::HashMap,
     env,
-    fs::{
-        create_dir_all, metadata as fs_metadata, read_dir, read_to_string, remove_dir_all,
-        OpenOptions,
-    },
+    fs::{create_dir_all, read_dir, read_to_string, remove_dir_all, OpenOptions},
     io::Write,
     path::{Path, PathBuf},
     process::Command,
@@ -13,10 +10,8 @@ use std::{
 use dotenv::dotenv;
 use ethers::prelude::Abigen;
 use eyre::Result;
-use filetime::FileTime;
 use heck::ToSnakeCase;
 use serde::{Deserialize, Serialize};
-use walkdir::WalkDir;
 
 const HYPERDRIVE_URL: &str = "https://github.com/delvtech/hyperdrive.git";
 


### PR DESCRIPTION
# Resolved Issues
Making testing more consistent to help narrow problems found when investigating https://github.com/delvtech/hyperdrive-rs/issues/29

# Description
- single preamble
We had 3x duplicates of a `preamble` function that would execute a series of trades on the deployed test pool in order to simulate testing from a random state. I consolidated it into one location that is imported elsewhere. I also added some checks on upper trade bounds so that it is guaranteed to be valid, even if calc_max fails.

- code cleanup
This seemingly innocuous change caused a difficult-to-track Hisenbug where the ERC20 contract would throw an overflow/underflow error whenever we'd call `hyperdrive.open_long` or `hyperdrive.open_short`. This was due to lack of approval, which was due to the approval call not going through before the open call, which was due to anvil not being able to keep up with the rust calls coming in. 
I fixed that bug (thanks to @mcclurejt for the help!) and in the process of hunting down that bug did a bunch of code cleanup stuff like improved error messaging, variable names, organization, etc.
I'm was able to consistently reproduce #4 while tracking this bug, and the fix we implemented seems to have also fixed that one.

- new tests
I also wrote a couple of new tests while hunting the Heisenbug.

### NOTE:
I had to increase test tolerance for `fuzz_sol_calc_open_short` from 1e9 to 10e18. My best guess as to why this happened is because we're now testing a wider variety of valid states and we're hitting error modes. I know that `calculate_open_short` does not match solidity exactly, so most likely this is the source of the error. I added a comment as a reminder in #29, but for now I think we should live with the high tolerance.

That being said, I encourage the reviewer to look carefully. I may have missed a change in this PR that is causing such a big error.