### PR TITLE
update `calc_open_short` to match solidity

### DIFF
--- a/.github/workflows/dynamic_fuzz.yml
+++ b/.github/workflows/dynamic_fuzz.yml
@@ -12,7 +12,7 @@ jobs:
       pattern: ^test/\|^crates/\|^lib/\|^target/\|^Cargo\.lock$\|^Cargo\.toml$\|^\.github/workflows/dynamic_fuzz\.yml$
 
   test:
-    name: dynamic fuzz
+    name: extended fuzz on new tests
     runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.changed == 'true'
@@ -45,7 +45,7 @@ jobs:
           git checkout ${{ github.head_ref }}
           sh scripts/list_tests.sh > branch_tests.txt
 
-      - name: Compare test lists and run new tests
+      - name: Compare test lists and run new tests with 10x fuzz runs
         run: |
           new_tests=$(diff main_tests.txt branch_tests.txt|awk -F'[>,]' '{gsub(/ /,"")} {print $2} '| sed '/^$/d')
           if [ -n "$new_tests" ]; then
@@ -53,7 +53,7 @@ jobs:
             echo "$new_tests"
             while IFS= read -r test; do
               echo "Running test: $test"
-              env HYPERDRIVE_FUZZ_RUNS=500 HYPERDRIVE_FAST_FUZZ_RUNS=50000 cargo test --release $test --
+              env HYPERDRIVE_SLOW_FUZZ_RUNS=500 HYPERDRIVE_FUZZ_RUNS=1000 HYPERDRIVE_FAST_FUZZ_RUNS=10000 cargo test --release $test --
             done <<< "$new_tests"
           else
             echo "No new tests found."

--- a/crates/hyperdrive-math/src/base.rs
+++ b/crates/hyperdrive-math/src/base.rs
@@ -14,6 +14,17 @@ impl State {
         }
     }
 
+    /// Calculates the pool's solvency.
+    ///
+    /// $$
+    /// s = z - \tfrac{exposure}{c} - z_min
+    /// $$
+    pub fn calculate_solvency(&self) -> FixedPoint {
+        self.share_reserves()
+            - self.long_exposure() / self.vault_share_price()
+            - self.minimum_share_reserves()
+    }
+
     /// Calculates the number of base that are not reserved by open positions.
     pub fn calculate_idle_share_reserves_in_base(&self) -> FixedPoint {
         // NOTE: Round up to underestimate the pool's idle.

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -23,17 +23,6 @@ impl State {
             .mul_up(fixed!(1e18) - self.flat_fee()))
     }
 
-    /// Calculates the pool's solvency.
-    ///
-    /// $$
-    /// s = z - \tfrac{exposure}{c} - z_min
-    /// $$
-    pub fn calculate_solvency(&self) -> FixedPoint {
-        self.share_reserves()
-            - self.long_exposure() / self.vault_share_price()
-            - self.minimum_share_reserves()
-    }
-
     /// Calculates the max long that can be opened given a budget.
     ///
     /// We start by calculating the long that brings the pool's spot price to 1.

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -424,14 +424,15 @@ impl State {
         checkpoint_exposure: I256,
     ) -> Result<FixedPoint> {
         let checkpoint_exposure_shares =
-            FixedPoint::try_from(checkpoint_exposure.max(I256::zero()))? / self.vault_share_price();
+            FixedPoint::try_from(checkpoint_exposure.max(I256::zero()))?
+                .div_down(self.vault_share_price());
         let guess = self.vault_share_price().mul_down(
             self.share_reserves() + checkpoint_exposure_shares
                 - self.long_exposure().div_down(self.vault_share_price())
                 - self.minimum_share_reserves(),
         );
-        let curve_fee = self.curve_fee() * (fixed!(1e18) - spot_price);
-        let gov_curve_fee = self.governance_lp_fee() * curve_fee;
+        let curve_fee = self.curve_fee().mul_down(fixed!(1e18) - spot_price);
+        let gov_curve_fee = self.governance_lp_fee().mul_down(curve_fee);
         Ok(guess.div_down(spot_price - curve_fee + gov_curve_fee))
     }
 

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -333,7 +333,7 @@ impl State {
 
     /// Calculates the absolute max short that can be opened without violating the
     /// pool's solvency constraints.
-    fn calculate_absolute_max_short(
+    pub fn calculate_absolute_max_short(
         &self,
         spot_price: FixedPoint,
         checkpoint_exposure: I256,

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -747,8 +747,8 @@ mod tests {
 
     #[tokio::test]
     async fn fuzz_sol_calculate_max_short_without_budget_then_open_short() -> Result<()> {
-        let max_base_tolerance = fixed!(10e18);
-        let max_bonds_tolerance = fixed!(1e2);
+        let max_base_tolerance = fixed!(1e16);
+        let max_bonds_tolerance = fixed!(1e8);
         let reserves_drained_tolerance = fixed!(1e27);
 
         // Set up a random number generator. We use ChaCha8Rng with a randomly
@@ -772,6 +772,7 @@ mod tests {
 
             // Run the preamble.
             initialize_pool_with_random_state(&mut rng, &mut alice, &mut bob, &mut celine).await?;
+            alice.advance_time(fixed!(0), fixed!(1)).await?;
 
             // Get the current state from solidity.
             let state = alice.get_state().await?;

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -175,7 +175,7 @@ impl State {
 
             // We update the best valid max bond amount if the deposit amount
             // is valid and the current guess is bigger than the previous best.
-            if deposit <= target_budget && max_bond_amount > best_valid_max_bond_amount {
+            if deposit <= target_budget && max_bond_amount >= best_valid_max_bond_amount {
                 best_valid_max_bond_amount = max_bond_amount;
                 // Stop if we found the exact solution.
                 if deposit == target_budget {

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -426,11 +426,11 @@ impl State {
         let checkpoint_exposure_shares =
             FixedPoint::try_from(checkpoint_exposure.max(I256::zero()))?
                 .div_down(self.vault_share_price());
-        let guess = self.vault_share_price().mul_down(
-            self.share_reserves() + checkpoint_exposure_shares
-                - self.long_exposure().div_down(self.vault_share_price())
-                - self.minimum_share_reserves(),
-        );
+        // solvency = share_reserves - long_exposure / vault_share_price - min_share_reserves
+        let solvency = self.calculate_solvency();
+        let guess = self
+            .vault_share_price()
+            .mul_down(solvency + checkpoint_exposure_shares);
         let curve_fee = self.curve_fee().mul_down(fixed!(1e18) - spot_price);
         let gov_curve_fee = self.governance_lp_fee().mul_down(curve_fee);
         Ok(guess.div_down(spot_price - curve_fee + gov_curve_fee))

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -96,7 +96,6 @@ impl State {
         let curve_fee_shares = self
             .open_short_curve_fee(bond_amount)?
             .div_up(self.vault_share_price());
-
         if share_reserves_delta < curve_fee_shares {
             return Err(eyre!(format!(
                 "The transaction curve fee = {}, computed with coefficient = {},
@@ -179,7 +178,7 @@ impl State {
         // reimbursed upon closing.
         let close_vault_share_price = open_vault_share_price.max(self.vault_share_price());
 
-        // Short circuit the derivative if the forward function returns 0.
+        // Short circuit the derivative if the function returns 0.
         if self.calculate_short_proceeds_up(
             bond_amount,
             self.calculate_short_principal(bond_amount)?
@@ -198,7 +197,7 @@ impl State {
             None => self.calculate_spot_price()?,
         };
 
-        // All of these are in base
+        // All of these are in base.
         let share_adjustment_derivative =
             close_vault_share_price.div_up(open_vault_share_price) + self.flat_fee();
         let short_principal_derivative = self

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -486,10 +486,10 @@ mod tests {
             {
                 Ok(sol_pool_deltas) => {
                     let sol_pool_deltas_with_fees = FixedPoint::from(sol_pool_deltas) - fees;
-                    let actual_with_fees = rust_pool_deltas.unwrap();
+                    let rust_pool_deltas_unwrapped = rust_pool_deltas.unwrap();
                     let result_equal = sol_pool_deltas_with_fees
-                        <= actual_with_fees + test_tolerance
-                        && sol_pool_deltas_with_fees >= actual_with_fees - test_tolerance;
+                        <= rust_pool_deltas_unwrapped + test_tolerance
+                        && sol_pool_deltas_with_fees >= rust_pool_deltas_unwrapped - test_tolerance;
                     assert!(result_equal, "Should be equal.");
                 }
                 Err(_) => {
@@ -666,8 +666,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fuzz_calculate_spot_price_after_short() -> Result<()> {
-        let test_tolerance = fixed!(10);
+    async fn fuzz_sol_calculate_spot_price_after_short() -> Result<()> {
+        let test_tolerance = fixed!(1e3);
 
         // Spawn a test chain and create two agents -- Alice and Bob. Alice is
         // funded with a large amount of capital so that she can initialize the
@@ -702,10 +702,10 @@ mod tests {
             // Open the short.
             bob.open_short(bond_amount, None, None).await?;
 
-            // Calling the solidity OpenShort causes the mock yield
-            // source to accrue some interest. We want to use the state
-            // before the Solidity OpenShort, but with the vault share
-            // price after the block tick.
+            // Calling any Solidity Hyperdrive transaction causes the
+            // mock yield source to accrue some interest. We want to use
+            // the state before the Solidity OpenShort, but with the
+            // vault share price after the block tick.
             let new_state = alice.get_state().await?;
             let new_vault_share_price = new_state.vault_share_price();
             state.info.vault_share_price = new_vault_share_price.into();
@@ -1012,10 +1012,10 @@ mod tests {
                 .await
             {
                 Ok((_, sol_base)) => {
-                    // Calling the solidity OpenShort causes the mock yield
-                    // source to accrue some interest. We want to use the state
-                    // before the Solidity OpenShort, but with the vault share
-                    // price after the block tick.
+                    // Calling any Solidity Hyperdrive transaction causes the
+                    // mock yield source to accrue some interest. We want to use
+                    // the state before the Solidity OpenShort, but with the
+                    // vault share price after the block tick.
 
                     // Get the current vault share price & update state.
                     let vault_share_price = alice.get_state().await?.vault_share_price();

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -874,10 +874,12 @@ mod tests {
     // Tests open short with an amount smaller than the minimum.
     #[tokio::test]
     async fn test_error_open_short_min_txn_amount() -> Result<()> {
+        let min_bond_delta = fixed!(1);
+
         let mut rng = thread_rng();
         let state = rng.gen::<State>();
         let result = state.calculate_open_short(
-            (state.config.minimum_transaction_amount - 10).into(),
+            state.minimum_transaction_amount() - min_bond_delta,
             state.vault_share_price(),
         );
         assert!(result.is_err());

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -1,32 +1,58 @@
-use ethers::{providers::maybe, types::I256};
+use ethers::types::I256;
 use eyre::{eyre, Result};
 use fixed_point::{fixed, FixedPoint};
 
 use crate::{calculate_rate_given_fixed_price, State, YieldSpace};
 
 impl State {
-    /// Calculates the amount of base the trader will need to deposit for a short of
-    /// a given size.
+    /// Calculates the amount of base the trader will need to deposit for a
+    /// short of a given size.
     ///
-    /// We can write out the short deposit function as:
+    /// For some number of bonds being shorted, $\Delta y$, the short deposit,
+    /// $D(\Delta y)$, is made up of several components:
+    ///
+    /// - The short principal:
+    ///   $P_{\text{lp}}(\Delta y)$
+    /// - The curve fee:
+    ///   $\Phi_{c,os}(\Delta y) = \phi_{c} \cdot ( 1 - p_{0} ) \cdot \Delta y$
+    /// - The governance-curve fee:
+    ///   $\Phi_{g,os}(\Delta y) = \phi_{g} \Phi_{c,os}(\Delta y)$
+    /// - The flat fee:
+    ///   $\Phi_{f,os}(\Delta y) = \tfrac{1}{c} ( \Delta y \cdot (1 - t) \cdot \phi_{f} )$
+    /// - The total value in shares that underlies the bonds:
+    ///   $\tfrac{c_1}{c_0 \cdot c} \Delta y$
+    ///
+    /// The short principal is given by:
     ///
     /// $$
-    /// D(\Delta y) = \Delta y - (c \cdot P(\Delta y) - \phi_{curve} \cdot (1 - p) \cdot \Delta y)
-    ///        + (c - c_0) \cdot \tfrac{\Delta y}{c_0} + \phi_{flat} \cdot \Delta y \\
-    ///      = \tfrac{c}{c_0} \cdot \Delta y - (c \cdot P(\Delta y) - \phi_{curve} \cdot (1 - p) \cdot \Delta y)
-    ///        + \phi_{flat} \cdot \Delta y
+    /// P_{\text{lp}}(\Delta y) = z - \tfrac{1}{\mu} \cdot (
+    ///     \tfrac{\mu}{c} \cdot (k - (y + \Delta y)^{1 - t_s})
+    /// )^{\tfrac{1}{1 - t_s}}
     /// $$
     ///
-    /// $\Delta y$ is the number of bonds being shorted and $P(\Delta y)$ is the amount of
-    /// shares the curve says the LPs need to pay the shorts (i.e. the LP
-    /// principal).
+    /// The adjusted value in shares that underlies the bonds is given by:
+    ///
+    /// $$
+    /// P_\text{adj} = (\frac{c_1}{c_0} + \phi_f) \cdot \frac{\Delta y}{c}
+    /// $$
+    ///
+    /// And finally the short deposit in base is:
+    ///
+    /// $$
+    /// D(\Delta y) =
+    /// \begin{cases}
+    ///     P_\text{adj} - P_{\text{lp}}(\Delta y) + \Phi_{c}(\Delta y)
+    ///       & \text{if } P_{\text{adj}} > P_{\text{lp}}(\Delta y) - \Phi_{c}(\Delta y) \\
+    ///     0, & \text{otherwise}
+    /// \end{cases}
+    /// $$
     pub fn calculate_open_short(
         &self,
         bond_amount: FixedPoint,
         open_vault_share_price: FixedPoint,
     ) -> Result<FixedPoint> {
-        // Verify that the bond amount is high enough.
-        // This is checked in Solidity but at a later stage.
+        // Ensure that the bond amount is greater than or equal to the minimum
+        // transaction amount.
         if bond_amount < self.minimum_transaction_amount() {
             return Err(eyre!(
                 "MinimumTransactionAmount: Input amount too low. bond_amount = {:#?} must be >= {:#?}",
@@ -44,44 +70,102 @@ impl State {
             open_vault_share_price
         };
 
-        // Calculate the effect that opening the short will have on the pool's reserves.
-        let share_reserves_delta_in_base = self
-            .vault_share_price()
-            .mul_up(self.calculate_short_principal(bond_amount)?);
+        // Calculate the effect that opening the short will have on the pool's
+        // share reserves.
+        let share_reserves_delta = self.calculate_short_principal(bond_amount)?;
+
+        // NOTE: Round up to make the check stricter.
+        //
         // If the base proceeds of selling the bonds is greater than the bond
         // amount, then the trade occurred in the negative interest domain.
         // We revert in these pathological cases.
-        if share_reserves_delta_in_base > bond_amount {
+        if share_reserves_delta.mul_up(self.vault_share_price()) > bond_amount {
             return Err(eyre!(
                 "InsufficientLiquidity: Negative Interest.
-                expected bond_amount={} <= share_reserves_delta_in_base={}",
+                expected bond_amount={} <= share_reserves_delta_in_shares={}",
                 bond_amount,
-                share_reserves_delta_in_base
+                share_reserves_delta
             ));
         }
 
-        // NOTE: The order of additions and subtractions is important to avoid underflows.
-        let spot_price = self.calculate_spot_price()?;
-        Ok(
-            bond_amount.mul_div_down(self.vault_share_price(), open_vault_share_price)
-                + self.flat_fee() * bond_amount
-                + self.curve_fee() * (fixed!(1e18) - spot_price) * bond_amount
-                - share_reserves_delta_in_base,
-        )
+        // NOTE: Round up to overestimate the base deposit.
+        //
+        // The trader will need to deposit capital to pay for the fixed rate,
+        // the fees, and any back-paid interest that will be received back upon
+        // closing the trade.
+        let curve_fee_shares = self
+            .open_short_curve_fee(bond_amount)?
+            .div_up(self.vault_share_price());
+
+        if share_reserves_delta < curve_fee_shares {
+            return Err(eyre!(format!(
+                "The transaction curve fee = {}, computed with coefficient = {},
+                is too high. It must be less than share reserves delta = {}",
+                curve_fee_shares,
+                self.curve_fee(),
+                share_reserves_delta
+            )));
+        }
+
+        // If negative interest has accrued during the current checkpoint, we
+        // set the close vault share price to equal the open vault share price.
+        // This ensures that shorts don't benefit from negative interest that
+        // accrued during the current checkpoint.
+        let close_vault_share_price = open_vault_share_price.max(self.vault_share_price());
+
+        // Now we can calculate adjusted proceeds account for the backdated
+        // vault price:
+        //
+        // $$
+        // \text{base_proceeds} = (
+        //    \frac{c1 \cdot \Delta y}{c0 \cdot c}
+        //    + \frac{\Delta y \cdot \phi_f}{c} - \Delta z
+        // ) \cdot c
+        // $$
+        let base_proceeds = self
+            .calculate_short_proceeds_up(
+                bond_amount,
+                share_reserves_delta - curve_fee_shares,
+                open_vault_share_price,
+                close_vault_share_price,
+            )
+            .mul_up(self.vault_share_price());
+
+        Ok(base_proceeds)
     }
 
-    /// Calculates the derivative of the short deposit function with respect to the
-    /// short amount. This allows us to use Newton's method to approximate the
-    /// maximum short that a trader can open.
+    /// Calculates the derivative of the short deposit function with respect to
+    /// the short amount.
     ///
-    /// Using this, calculating $D'(\Delta y)$ is straightforward:
-    ///
-    /// $$
-    /// D'(\Delta y) = \tfrac{c}{c_0} - (c \cdot P'(\Delta y) - \phi_{curve} \cdot (1 - p)) + \phi_{flat}
-    /// $$
+    /// This derivative allows us to use Newton's method to approximate the
+    /// maximum short that a trader can open. The share adjustment derivative is
+    /// a constant:
     ///
     /// $$
-    /// P'(\Delta y) = \tfrac{1}{c} \cdot (y + \Delta y)^{-t_s} \cdot \left(\tfrac{\mu}{c} \cdot (k - (y + \Delta y)^{1 - t_s}) \right)^{\tfrac{t_s}{1 - t_s}}
+    /// P^{\prime}_{\text{adj}}(\Delta y) = \tfrac{c_{1}}{c_{0} \cdot c} + \tfrac{\phi_{f}}{c}
+    /// $$
+    ///
+    /// The curve fee dervative is given by:
+    ///
+    /// $$
+    /// \Phi^{\prime}_{\text{c}}(\Delta y) = \phi_{c} \cdot (1 - p_0),
+    /// $$
+    ///
+    /// where $p_0$ is the opening (or initial) spot price. Using these and the
+    /// short principal derivative, we can calculate the open short derivative:
+    ///
+    /// $$
+    /// D^{\prime}(\Delta y) =
+    ///\begin{cases}
+    ///    c \cdot \left(
+    ///      P^{\prime}_{\text{adj}}(\Delta y)
+    ///      - P^{\prime}_{\text{lp}}(\Delta y)
+    ///      + \Phi^{\prime}_{c,os}(\Delta y)
+    ///    \right),
+    ///    & \text{if }
+    ///      P_{\text{adj}} > P_{\text{lp}}(\Delta y) - \Phi_{c,os}(\Delta y) \\
+    ///    0, & \text{otherwise}
+    ///\end{cases}
     /// $$
     pub fn calculate_open_short_derivative(
         &self,
@@ -89,72 +173,94 @@ impl State {
         open_vault_share_price: FixedPoint,
         maybe_initial_spot_price: Option<FixedPoint>,
     ) -> Result<FixedPoint> {
+        // We're avoiding negative interest, so we will cap the close share
+        // price to be greater than or equal to the open share price. This
+        // will assume the max loss for the trader, some of which may be
+        // reimbursed upon closing.
+        let close_vault_share_price = open_vault_share_price.max(self.vault_share_price());
+
+        // Short circuit the derivative if the forward function returns 0.
+        if self.calculate_short_proceeds_up(
+            bond_amount,
+            self.calculate_short_principal(bond_amount)?
+                - self
+                    .open_short_curve_fee(bond_amount)?
+                    .div_up(self.vault_share_price()),
+            open_vault_share_price,
+            close_vault_share_price,
+        ) == fixed!(0)
+        {
+            return Ok(fixed!(0));
+        }
+
         let spot_price = match maybe_initial_spot_price {
             Some(spot_price) => spot_price,
             None => self.calculate_spot_price()?,
         };
 
-        // Theta calculates the inner component of the `short_principal` calculation,
-        // which makes the `short_principal` and `short_deposit_derivative` calculations
-        // easier. $\theta(\Delta y)$ is defined as:
-        //
-        // $$
-        // \theta(\Delta y) = \tfrac{\mu}{c} \cdot (k - (y + \Delta y)^{1 - t_s})
-        // $$
-        let theta = (self.initial_vault_share_price() / self.vault_share_price())
-            * (self.k_down()?
-                - (self.bond_reserves() + bond_amount).pow(fixed!(1e18) - self.time_stretch())?);
-        // NOTE: The order of additions and subtractions is important to avoid underflows.
-        let payment_factor = (fixed!(1e18)
-            / (self.bond_reserves() + bond_amount).pow(self.time_stretch())?)
-            * theta.pow(self.time_stretch() / (fixed!(1e18) - self.time_stretch()))?;
-        Ok((self.vault_share_price() / open_vault_share_price)
-            + self.flat_fee()
-            + self.curve_fee() * (fixed!(1e18) - spot_price)
-            - payment_factor)
+        // All of these are in base
+        let share_adjustment_derivative =
+            close_vault_share_price.div_up(open_vault_share_price) + self.flat_fee();
+        let short_principal_derivative = self
+            .calculate_short_principal_derivative(bond_amount)?
+            .mul_up(self.vault_share_price());
+        let curve_fee_derivative = self.curve_fee().mul_up((fixed!(1e18) - spot_price));
+
+        // Multiply by the share price to return base.
+        Ok(share_adjustment_derivative - short_principal_derivative + curve_fee_derivative)
     }
 
     /// Calculates the amount of short principal that the LPs need to pay to back a
-    /// short before fees are taken into consideration, $P(\Delta y)$.
+    /// short before fees are taken into consideration, $P_\text{lp}(\Delta y)$.
     ///
-    /// Let the LP principal that backs $\Delta y$ shorts be given by $P(\Delta y)$. We can
-    /// solve for this in terms of $\Delta y$ using the YieldSpace invariant:
+    /// Let the LP principal that backs $\Delta y$ shorts be given by $P_{\text{lp}}(\Delta y)$.
+    /// We can solve for this in terms of $\Delta y$ using the YieldSpace invariant:
     ///
     /// $$
     /// k = \tfrac{c}{\mu} \cdot (\mu \cdot (z - P(\Delta y)))^{1 - t_s} + (y + \Delta y)^{1 - t_s} \\
     /// \implies \\
-    /// P(\Delta y) = z - \tfrac{1}{\mu} \cdot (\tfrac{\mu}{c} \cdot (k - (y + \Delta y)^{1 - t_s}))^{\tfrac{1}{1 - t_s}}
+    /// P_{\text{lp}}(\Delta y) = z - \tfrac{1}{\mu}
+    /// \cdot \left(
+    ///   \tfrac{\mu}{c} \cdot (k - (y + \Delta y)^{1 - t_s})
+    /// \right)^{\tfrac{1}{1 - t_s}}
     /// $$
     pub fn calculate_short_principal(&self, bond_amount: FixedPoint) -> Result<FixedPoint> {
         self.calculate_shares_out_given_bonds_in_down_safe(bond_amount)
     }
 
-    /// Calculates the derivative of the short principal $P(\Delta y)$ w.r.t. the amount of
-    /// bonds that are shorted $\Delta y$.
+    /// Calculates the derivative of the short principal w.r.t. the amount of
+    /// bonds that are shorted.
     ///
-    /// The derivative is calculated as:
+    /// The derivative is:
     ///
     /// $$
-    /// P'(\Delta y) = \tfrac{1}{c} \cdot (y + \Delta y)^{-t_s} \cdot \left(
-    ///             \tfrac{\mu}{c} \cdot (k - (y + \Delta y)^{1 - t_s})
-    ///         \right)^{\tfrac{t_s}{1 - t_s}}
+    /// P^{\prime}_{\text{lp}}(\Delta y) = \tfrac{1}{c} \cdot (y + \Delta y)^{-t_s}
+    /// \cdot \left(
+    ///     \tfrac{\mu}{c} \cdot (k - (y + \Delta y)^{1 - t_s})
+    /// \right)^{\tfrac{t_s}{1 - t_s}}
     /// $$
     pub fn calculate_short_principal_derivative(
         &self,
         bond_amount: FixedPoint,
     ) -> Result<FixedPoint> {
-        let lhs = fixed!(1e18)
-            / (self
-                .vault_share_price()
-                .mul_up((self.bond_reserves() + bond_amount).pow(self.time_stretch())?));
-        let rhs = ((self.initial_vault_share_price() / self.vault_share_price())
-            * (self.k_down()?
-                - (self.bond_reserves() + bond_amount).pow(fixed!(1e18) - self.time_stretch())?))
+        // Avoid negative exponent by putting the term in the denominator.
+        let lhs = fixed!(1e18).div_up(
+            self.vault_share_price()
+                .mul_up((self.bond_reserves() + bond_amount).pow(self.time_stretch())?),
+        );
+        let rhs = (self
+            .initial_vault_share_price()
+            .div_up(self.vault_share_price())
+            .mul_up(
+                self.k_up()?
+                    - (self.bond_reserves() + bond_amount)
+                        .pow(fixed!(1e18) - self.time_stretch())?,
+            ))
         .pow(
             self.time_stretch()
                 .div_up(fixed!(1e18) - self.time_stretch()),
         )?;
-        Ok(lhs * rhs)
+        Ok(lhs.mul_up(rhs))
     }
 
     /// Calculate an updated pool state after opening a short.
@@ -166,15 +272,15 @@ impl State {
     pub fn calculate_pool_state_after_open_short(
         &self,
         bond_amount: FixedPoint,
-        maybe_shares_amount: Option<FixedPoint>,
+        maybe_share_amount: Option<FixedPoint>,
     ) -> Result<Self> {
-        let shares_delta = match maybe_shares_amount {
-            Some(shares_amount) => shares_amount,
+        let share_amount = match maybe_share_amount {
+            Some(share_amount) => share_amount,
             None => self.calculate_pool_deltas_after_open_short(bond_amount)?,
         };
         let mut state = self.clone();
         state.info.bond_reserves += bond_amount.into();
-        state.info.share_reserves -= shares_delta.into();
+        state.info.share_reserves -= share_amount.into();
         Ok(state)
     }
 
@@ -203,33 +309,32 @@ impl State {
     }
 
     /// Calculates the spot price after opening a short.
+    /// Arguments are deltas that would be applied to the pool.
     pub fn calculate_spot_price_after_short(
         &self,
         bond_amount: FixedPoint,
         maybe_base_amount: Option<FixedPoint>,
     ) -> Result<FixedPoint> {
-        let shares_amount = match maybe_base_amount {
+        let share_amount = match maybe_base_amount {
             Some(base_amount) => base_amount / self.vault_share_price(),
             None => self.calculate_pool_deltas_after_open_short(bond_amount)?,
         };
         let updated_state =
-            self.calculate_pool_state_after_open_short(bond_amount, Some(shares_amount))?;
+            self.calculate_pool_state_after_open_short(bond_amount, Some(share_amount))?;
         updated_state.calculate_spot_price()
     }
 
     /// Calculate the spot rate after a short has been opened.
-    /// If a base_amount is not provided, then one is estimated using `calculate_open_short`.
+    /// If a base_amount is not provided, then one is estimated
+    /// using `calculate_pool_deltas_after_open_short`.
     ///
     /// We calculate the rate for a fixed length of time as:
     /// $$
-    /// r(\Delta y) = (1 - p(\Delta y)) / (p(\Delta y) t)
+    /// r(\Delta y) = (1 - p(\Delta y)) / (p(\Delta y) \cdot t)
     /// $$
     ///
     /// where $p(\Delta y)$ is the spot price after a short for `delta_bonds`$= \Delta y$ and
-    /// t is the normalized position druation.
-    ///
-    /// In this case, we use the resulting spot price after a hypothetical short
-    /// for `bond_amount` is opened.
+    /// $t$ is the normalized position druation.
     pub fn calculate_spot_rate_after_short(
         &self,
         bond_amount: FixedPoint,
@@ -314,7 +419,7 @@ mod tests {
     use fixed_point::{fixed, int256};
     use hyperdrive_test_utils::{
         chain::TestChain,
-        constants::{FAST_FUZZ_RUNS, FUZZ_RUNS},
+        constants::{FAST_FUZZ_RUNS, FUZZ_RUNS, SLOW_FUZZ_RUNS},
     };
     use hyperdrive_wrappers::wrappers::ihyperdrive::{Checkpoint, Options};
     use rand::{thread_rng, Rng, SeedableRng};
@@ -431,41 +536,51 @@ mod tests {
     async fn fuzz_calculate_short_principal_derivative() -> Result<()> {
         // We use a relatively large epsilon here due to the underlying fixed point pow
         // function not being monotonically increasing.
-        let empirical_derivative_epsilon = fixed!(1e12);
-        // TODO pretty big comparison epsilon here
-        let test_tolerance = fixed!(1e16);
+        let empirical_derivative_epsilon = fixed!(1e14);
+        let test_tolerance = fixed!(1e14);
 
         let mut rng = thread_rng();
         for _ in 0..*FAST_FUZZ_RUNS {
             let state = rng.gen::<State>();
-            let amount = rng.gen_range(fixed!(10e18)..=fixed!(10_000_000e18));
 
-            let p1 = match state.calculate_short_principal(amount - empirical_derivative_epsilon) {
-                // If the amount results in the pool being insolvent, skip this iteration
-                Ok(p) => p,
-                Err(_) => continue,
+            // Min trade amount should be at least 1,000x the derivative epsilon.
+            let bond_amount = rng.gen_range(fixed!(1e18)..=fixed!(10_000_000e18));
+
+            // Calculate the function output at the bond amount and a small perturbation away.
+            let f_x = match panic::catch_unwind(|| state.calculate_short_principal(bond_amount)) {
+                Ok(result) => match result {
+                    Ok(result) => result,
+                    Err(_) => continue, // The amount resulted in the pool being insolvent.
+                },
+                Err(_) => continue, // Overflow or underflow error from FixedPoint.
+            };
+            let f_x_plus_delta = match panic::catch_unwind(|| {
+                state.calculate_short_principal(bond_amount + empirical_derivative_epsilon)
+            }) {
+                Ok(result) => match result {
+                    Ok(result) => result,
+                    Err(_) => continue, // The amount resulted in the pool being insolvent.
+                },
+                Err(_) => continue, // Overflow or underflow error from FixedPoint.
             };
 
-            let p2 = match state.calculate_short_principal(amount + empirical_derivative_epsilon) {
-                // If the amount results in the pool being insolvent, skip this iteration
-                Ok(p) => p,
-                Err(_) => continue,
-            };
             // Sanity check
-            assert!(p2 > p1);
+            assert!(f_x_plus_delta > f_x);
 
-            let empirical_derivative = (p2 - p1) / (fixed!(2e18) * empirical_derivative_epsilon);
-            let short_principal_derivative = state.calculate_short_principal_derivative(amount)?;
+            // Compute the empirical and analytical derivatives.
+            let empirical_derivative = (f_x_plus_delta - f_x) / empirical_derivative_epsilon;
+            let short_principal_derivative =
+                state.calculate_short_principal_derivative(bond_amount)?;
 
-            let derivative_diff;
-            if short_principal_derivative >= empirical_derivative {
-                derivative_diff = short_principal_derivative - empirical_derivative;
+            // Enxure that the empirical and analytical derivatives match.
+            let derivative_diff = if short_principal_derivative >= empirical_derivative {
+                short_principal_derivative - empirical_derivative
             } else {
-                derivative_diff = empirical_derivative - short_principal_derivative;
-            }
+                empirical_derivative - short_principal_derivative
+            };
             assert!(
                 derivative_diff < test_tolerance,
-                "expected (derivative_diff={}) < (test_tolerance={}), \
+                "expected abs(derivative_diff={}) < test_tolerance={};
                 calculated_derivative={}, emperical_derivative={}",
                 derivative_diff,
                 test_tolerance,
@@ -484,64 +599,59 @@ mod tests {
     async fn fuzz_calculate_open_short_derivative() -> Result<()> {
         // We use a relatively large epsilon here due to the underlying fixed point pow
         // function not being monotonically increasing.
-        let empirical_derivative_epsilon = fixed!(1e12);
-        // TODO pretty big comparison epsilon here
-        let test_tolerance = fixed!(1e15);
+        let empirical_derivative_epsilon = fixed!(1e14);
+        let test_tolerance = fixed!(1e14);
 
         let mut rng = thread_rng();
         for _ in 0..*FAST_FUZZ_RUNS {
             let state = rng.gen::<State>();
-            let amount = rng.gen_range(fixed!(10e18)..=fixed!(10_000_000e18));
+            // Min trade amount should be at least 1,000x the derivative epsilon.
+            let bond_amount = rng.gen_range(fixed!(1e18)..=fixed!(10_000_000e18));
 
-            let p1 = match panic::catch_unwind(|| {
-                state.calculate_open_short(
-                    amount - empirical_derivative_epsilon,
-                    state.vault_share_price(),
-                )
+            // Calculate the function output at the bond amount and a small perturbation away.
+            let f_x = match panic::catch_unwind(|| {
+                state.calculate_open_short(bond_amount, state.vault_share_price())
             }) {
-                Ok(p) => match p {
-                    Ok(p) => p,
+                Ok(result) => match result {
+                    Ok(result) => result,
                     Err(_) => continue, // The amount results in the pool being insolvent.
                 },
                 Err(_) => continue, // Overflow or underflow error from FixedPoint.
             };
-
-            let p2 = match panic::catch_unwind(|| {
+            let f_x_plus_delta = match panic::catch_unwind(|| {
                 state.calculate_open_short(
-                    amount + empirical_derivative_epsilon,
+                    bond_amount + empirical_derivative_epsilon,
                     state.vault_share_price(),
                 )
             }) {
-                // If the amount results in the pool being insolvent, skip this iteration
-                Ok(p) => match p {
-                    Ok(p) => p,
+                Ok(result) => match result {
+                    Ok(result) => result,
                     Err(_) => continue, // The amount results in the pool being insolvent.
                 },
                 Err(_) => continue, // Overflow or underflow error from FixedPoint.
             };
 
             // Sanity check
-            assert!(p2 > p1);
+            assert!(f_x_plus_delta > f_x);
 
-            // Compute the derivative.
-            let empirical_derivative = (p2 - p1) / (fixed!(2e18) * empirical_derivative_epsilon);
-
+            // Compute the empirical and analytical derivatives.
             // Setting open, close, and current vault share price to be equal assumes 0% variable yield.
+            let empirical_derivative = (f_x_plus_delta - f_x) / empirical_derivative_epsilon;
             let short_deposit_derivative = state.calculate_open_short_derivative(
-                amount,
+                bond_amount,
                 state.vault_share_price(),
                 Some(state.calculate_spot_price()?),
             )?;
 
-            let derivative_diff;
-            if short_deposit_derivative >= empirical_derivative {
-                derivative_diff = short_deposit_derivative - empirical_derivative;
+            // Enxure that the empirical and analytical derivatives match.
+            let derivative_diff = if short_deposit_derivative >= empirical_derivative {
+                short_deposit_derivative - empirical_derivative
             } else {
-                derivative_diff = empirical_derivative - short_deposit_derivative;
-            }
+                empirical_derivative - short_deposit_derivative
+            };
             assert!(
                 derivative_diff < test_tolerance,
-                "expected (derivative_diff={}) < (test_comparison_epsilon={}), \
+                "expected abs(derivative_diff={}) < test_tolerance={};
                 calculated_derivative={}, emperical_derivative={}",
                 derivative_diff,
                 test_tolerance,
@@ -586,10 +696,11 @@ mod tests {
             alice.advance_time(fixed!(0), fixed!(1)).await?;
 
             // Attempt to predict the spot price after opening a short.
-            let bond_amount = rng.gen_range(fixed!(0.01e18)..=bob.calculate_max_short(None).await?);
-            let current_state = bob.get_state().await?;
-            let expected_spot_price =
-                current_state.calculate_spot_price_after_short(bond_amount, None)?;
+            let state = alice.get_state().await?;
+            let bond_amount = rng.gen_range(
+                state.minimum_transaction_amount()..=bob.calculate_max_short(None).await?,
+            );
+            let expected_spot_price = state.calculate_spot_price_after_short(bond_amount, None)?;
 
             // Open the short.
             bob.open_short(bond_amount, None, None).await?;
@@ -613,10 +724,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fuzz_defaults_calculate_spot_price_after_short() -> Result<()> {
+    async fn test_defaults_calculate_spot_price_after_short() -> Result<()> {
         let mut rng = thread_rng();
         let mut num_checks = 0;
-        for _ in 0..*FUZZ_RUNS {
+        // We don't need a lot of tests for this because each component is
+        // tested elsewhere.
+        for _ in 0..*SLOW_FUZZ_RUNS {
             // We use a random state but we will ignore any case where a call
             // fails because we want to test the default behavior when the state
             // allows all actions.
@@ -629,15 +742,12 @@ mod tests {
                     I256::try_from(value).unwrap()
                 }
             };
-            let open_vault_share_price = rng.gen_range(fixed!(0)..=state.vault_share_price());
             // We need to catch panics because of overflows.
             let max_bond_amount = match panic::catch_unwind(|| {
-                state.calculate_max_short(
-                    U256::MAX,
-                    open_vault_share_price,
+                state.calculate_absolute_max_short(
+                    state.calculate_spot_price()?,
                     checkpoint_exposure,
-                    None,
-                    None,
+                    Some(3),
                 )
             }) {
                 Ok(max_bond_amount) => match max_bond_amount {
@@ -794,14 +904,11 @@ mod tests {
             };
             let max_iterations = 7;
             let open_vault_share_price = rng.gen_range(fixed!(0)..=state.vault_share_price());
-            // TODO: We should use calculate_absolute_max_short here because that is what we are testing.
             // We need to catch panics because of FixedPoint overflows & underflows.
             let max_trade = panic::catch_unwind(|| {
-                state.calculate_max_short(
-                    U256::MAX,
-                    open_vault_share_price,
+                state.calculate_absolute_max_short(
+                    state.calculate_spot_price()?,
                     checkpoint_exposure,
-                    None,
                     Some(max_iterations),
                 )
             });


### PR DESCRIPTION
# Resolved Issues
https://github.com/delvtech/hyperdrive-rs/issues/29
https://github.com/delvtech/hyperdrive-rs/issues/121

# Description
This PR updates the Rust open short and derivative implementations to match Solidity.
With help from @sentilesdal I uncovered a bug with sol differential tests where the current vault share price was not correctly used on the rust end. Fixing this allowed us to drop several test tolerances as well. I'll follow up with another PR that applies this fix elsewhere.
I also did some minor variable renames, added & modified max short checks, and resolved a few lingering FIXMEs.
I ran all of the tests with 10x fuzz constants locally without any failures.

## Lower tolerances on tests 🎉 
- After the fix, I was able to completely remove the error tolerance on `fuzz_calc_open_short`.
- I also updated the epsilon & tolerance values for the `fuzz_short_deposit_derivative` and `fuzz_short_principal_derivative` tests. I use a larger epsilon and smaller tolerance, which I think is what we prefer (more distant points should match linearity assumptions better due to the lack of monotonicity coming from `pow`).
- `fuzz_sol_calculate_max_short_without_budget_then_open_short` lowered base test tolerance due to both the open short fix and the vault share price fix.

## Increased tolerances on tests 😭 
- I had to increase tolerance on `fuzz_calculate_spot_price_after_short` from `fixed!(0)` to `fixed!(100)`. However, the test is more difficult now because it uses a random variable rate instead of 0%.
  - note: `test_sol_calculate_pool_deltas_after_open_short` looks like it has a new tolerance, but this was simply assigning an existing tolerance to a variable at the top of the test.
- `fuzz_sol_calculate_max_short_without_budget_then_open_short`  raised bond test tolerance from 1e2 to 1e10, but 1e2 wasn't holding up to extensive fuzz testing in the first place.

## Math outline
The below formulation follows the logic outlined in `HyperdriveShort.sol`. I made some slight changes to variable names and ordering of presentation.

![image](https://github.com/delvtech/hyperdrive-rs/assets/153468/a3f0a888-a46b-4c03-b530-3ff4dbdc62af)
![image](https://github.com/delvtech/hyperdrive-rs/assets/153468/71dceb73-270b-4274-8022-b17968a45a43)
![image](https://github.com/delvtech/hyperdrive-rs/assets/153468/f69844c8-028c-4cdb-9efa-7f31b88c8fc6)

