### PR TITLE
Move fixedpointmath macro logic to utils

### DIFF
--- a/crates/fixedpointmath/Cargo.toml
+++ b/crates/fixedpointmath/Cargo.toml
@@ -12,7 +12,7 @@ description = "Math library to simulate FixedPoint computation in Solidity smart
 [dependencies]
 
 # External dependencies
-ethers = "2.0.11"
+ethers = { version = "2.0.11", default-features = false }
 eyre = "0.6.8"
 rand = "0.8.5"
 

--- a/crates/fixedpointmath/src/lib.rs
+++ b/crates/fixedpointmath/src/lib.rs
@@ -1,6 +1,10 @@
+mod macros;
+mod utils;
+
 use std::{
     fmt,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Shr, Sub, SubAssign},
+    str::FromStr,
 };
 
 use ethers::types::{Sign, I256, U256};
@@ -12,7 +16,7 @@ use rand::{
     },
     Rng,
 };
-mod macros;
+pub use utils::*;
 
 /// A fixed point wrapper around the `U256` type from ethers-rs.
 ///
@@ -94,6 +98,14 @@ impl TryFrom<FixedPoint> for I256 {
     fn try_from(f: FixedPoint) -> Result<I256> {
         I256::checked_from_sign_and_abs(Sign::Positive, f.0)
             .ok_or(eyre!("failed to convert {} to I256", f))
+    }
+}
+
+impl FromStr for FixedPoint {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<FixedPoint> {
+        Ok(FixedPoint(u256_from_str(s)?))
     }
 }
 

--- a/crates/fixedpointmath/src/macros.rs
+++ b/crates/fixedpointmath/src/macros.rs
@@ -11,44 +11,7 @@
 macro_rules! uint256 {
     ($number:expr) => {{
         let str = stringify!($number);
-
-        // Parse a string into a mantissa and an exponent. The U256 arithmetic
-        // will overflow if the mantissa or the exponent are too large.
-        let mut found_dot = false;
-        let mut found_e = false;
-        let mut mantissa = ethers::types::U256::zero();
-        let mut exponent = ethers::types::U256::zero();
-        let mut decimals = 0;
-
-        for digit in str.chars() {
-            if digit.is_ascii_digit() {
-                let d = digit.to_digit(10).unwrap();
-                if !found_e {
-                    mantissa = mantissa * 10 + d;
-                } else {
-                    exponent = exponent * 10 + d;
-                }
-                if found_dot && !found_e {
-                    decimals += 1;
-                }
-            } else if digit == 'e' && !found_e {
-                found_e = true;
-            } else if digit == '.' && !found_dot {
-                found_dot = true;
-            } else if digit != '_' {
-                panic!("Unexpected character: {digit}");
-            }
-        }
-
-        // Combine the mantissa and the exponent into a single U256. This will
-        // overflow if the exponent is too large. We also need to make sure that
-        // the final result is an integer.
-        let decimals = ethers::types::U256::from(decimals);
-        if exponent < decimals {
-            panic!("Exponent is too small: {exponent}");
-        }
-
-        mantissa * ethers::types::U256::from(10).pow(exponent - decimals)
+        $crate::u256_from_str(str).unwrap()
     }};
 }
 
@@ -56,46 +19,7 @@ macro_rules! uint256 {
 macro_rules! int256 {
     ($number:expr) => {{
         let str = stringify!($number);
-
-        // Parse a string into a mantissa and an exponent. The U256 arithmetic
-        // will overflow if the mantissa or the exponent are too large.
-        let mut sign = ethers::types::I256::one();
-        let mut found_dot = false;
-        let mut found_e = false;
-        let mut mantissa = ethers::types::I256::zero();
-        let mut exponent = 0;
-        let mut decimals = 0;
-
-        for digit in str.chars() {
-            if digit.is_ascii_digit() {
-                let d = digit.to_digit(10).unwrap();
-                if !found_e {
-                    mantissa = mantissa * 10 + d;
-                } else {
-                    exponent = exponent * 10 + d;
-                }
-                if found_dot && !found_e {
-                    decimals += 1;
-                }
-            } else if digit == '-' {
-                sign = -ethers::types::I256::one();
-            } else if digit == 'e' && !found_e {
-                found_e = true;
-            } else if digit == '.' && !found_dot {
-                found_dot = true;
-            } else if digit != '_' {
-                panic!("Unexpected character: {digit}");
-            }
-        }
-
-        // Combine the mantissa and the exponent I256. This will
-        // overflow if the exponent is too large. We also need to make sure that
-        // the final result is an integer.
-        if exponent < decimals {
-            panic!("Exponent is too small: {exponent}");
-        }
-
-        sign * mantissa * ethers::types::I256::from(10).pow(exponent - decimals)
+        $crate::i256_from_str(str).unwrap()
     }};
 }
 

--- a/crates/fixedpointmath/src/utils.rs
+++ b/crates/fixedpointmath/src/utils.rs
@@ -10,7 +10,7 @@ use eyre::{eyre, Result};
 /// use fixedpointmath::u256_from_str;
 ///
 /// let u = u256_from_str("1.1e18").unwrap();
-/// assert_eq!(u, U256::from(11) * U256::from(10).pow(17));
+/// assert_eq!(u, U256::from(11) * U256::from(10).pow(U256::from(17)));
 /// ```
 pub fn u256_from_str(s: &str) -> Result<U256> {
     // Parse a string into a mantissa and an exponent. The U256 arithmetic

--- a/crates/fixedpointmath/src/utils.rs
+++ b/crates/fixedpointmath/src/utils.rs
@@ -91,7 +91,7 @@ pub fn i256_from_str(s: &str) -> Result<I256> {
         } else if digit == '.' && !found_dot {
             found_dot = true;
         } else if digit != '_' {
-            panic!("Unexpected character: {digit}");
+            return Err(eyre!("Unexpected character: {digit}"));
         }
     }
 
@@ -99,7 +99,7 @@ pub fn i256_from_str(s: &str) -> Result<I256> {
     // overflow if the exponent is too large. We also need to make sure that
     // the final result is an integer.
     if exponent < decimals {
-        panic!("Exponent is too small: {exponent}");
+        return Err(eyre!("Exponent is too small: {exponent}"));
     }
 
     Ok(sign * mantissa * ethers::types::I256::from(10).pow(exponent - decimals))

--- a/crates/fixedpointmath/src/utils.rs
+++ b/crates/fixedpointmath/src/utils.rs
@@ -1,0 +1,106 @@
+use ethers::types::{I256, U256};
+use eyre::{eyre, Result};
+
+/// Parse a string into a U256 with support for scientific and decimal notation.
+///
+/// ## Example
+///
+/// ```
+/// use ethers::types::U256;
+/// use fixedpointmath::u256_from_str;
+///
+/// let u = u256_from_str("1.1e18").unwrap();
+/// assert_eq!(u, U256::from(11) * U256::from(10).pow(17));
+/// ```
+pub fn u256_from_str(s: &str) -> Result<U256> {
+    // Parse a string into a mantissa and an exponent. The U256 arithmetic
+    // will overflow if the mantissa or the exponent are too large.
+    let mut found_dot = false;
+    let mut found_e = false;
+    let mut mantissa = ethers::types::U256::zero();
+    let mut exponent = ethers::types::U256::zero();
+    let mut decimals = 0;
+
+    for digit in s.chars() {
+        if digit.is_ascii_digit() {
+            let d = digit.to_digit(10).unwrap();
+            if !found_e {
+                mantissa = mantissa * 10 + d;
+            } else {
+                exponent = exponent * 10 + d;
+            }
+            if found_dot && !found_e {
+                decimals += 1;
+            }
+        } else if digit == 'e' && !found_e {
+            found_e = true;
+        } else if digit == '.' && !found_dot {
+            found_dot = true;
+        } else if digit != '_' {
+            return Err(eyre!("Unexpected character: {digit}"));
+        }
+    }
+
+    // Combine the mantissa and the exponent into a single U256. This will
+    // overflow if the exponent is too large. We also need to make sure that
+    // the final result is an integer.
+    let decimals = ethers::types::U256::from(decimals);
+    if exponent < decimals {
+        return Err(eyre!("Exponent is too small: {exponent}"));
+    }
+
+    Ok(mantissa * ethers::types::U256::from(10).pow(exponent - decimals))
+}
+
+/// Parse a string into an I256 with support for scientific and decimal notation.
+///
+/// ## Example
+///
+/// ```
+/// use ethers::types::I256;
+/// use fixedpointmath::i256_from_str;
+///
+/// let i = i256_from_str("-1.1e18").unwrap();
+/// assert_eq!(i, -I256::from(11) * I256::from(10).pow(17));
+/// ```
+pub fn i256_from_str(s: &str) -> Result<I256> {
+    // Parse a string into a mantissa and an exponent. The U256 arithmetic
+    // will overflow if the mantissa or the exponent are too large.
+    let mut sign = ethers::types::I256::one();
+    let mut found_dot = false;
+    let mut found_e = false;
+    let mut mantissa = ethers::types::I256::zero();
+    let mut exponent = 0;
+    let mut decimals = 0;
+
+    for digit in s.chars() {
+        if digit.is_ascii_digit() {
+            let d = digit.to_digit(10).unwrap();
+            if !found_e {
+                mantissa = mantissa * 10 + d;
+            } else {
+                exponent = exponent * 10 + d;
+            }
+            if found_dot && !found_e {
+                decimals += 1;
+            }
+        } else if digit == '-' {
+            sign = -ethers::types::I256::one();
+        } else if digit == 'e' && !found_e {
+            found_e = true;
+        } else if digit == '.' && !found_dot {
+            found_dot = true;
+        } else if digit != '_' {
+            panic!("Unexpected character: {digit}");
+        }
+    }
+
+    // Combine the mantissa and the exponent I256. This will
+    // overflow if the exponent is too large. We also need to make sure that
+    // the final result is an integer.
+    if exponent < decimals {
+        panic!("Exponent is too small: {exponent}");
+    }
+
+    Ok(sign * mantissa * ethers::types::I256::from(10).pow(exponent - decimals))
+}


### PR DESCRIPTION
# Description

This moves the logic of parsing strings into u256 and i256 types into util functions so that they can be re-used with normal strings. This will be useful when wrapping in WASM.

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed.

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
