### PR TITLE
Change `calculate_solvency` to return a `Result<FixedPoint>`

### DIFF
--- a/bindings/hyperdrivepy/src/hyperdrive_state_methods.rs
+++ b/bindings/hyperdrivepy/src/hyperdrive_state_methods.rs
@@ -29,7 +29,9 @@ impl HyperdriveState {
     }
 
     pub fn calculate_solvency(&self) -> PyResult<String> {
-        let result_fp = self.state.calculate_solvency();
+        let result_fp = self.state.calculate_solvency().map_err(|err| {
+            PyErr::new::<PyValueError, _>(format!("failed to calculate solvency: {}", err))
+        })?;
         let result = U256::from(result_fp).to_string();
         Ok(result)
     }

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -642,16 +642,8 @@ mod tests {
                 max_spot_price - spot_price_after_long.min(max_spot_price) < fixed!(1e15);
             let is_solvency_consumed = {
                 let state = alice.get_state().await?;
-                let checkpoint_exposure = FixedPoint::try_from(
-                    alice
-                        .get_checkpoint_exposure(state.to_checkpoint(alice.now().await?))
-                        .await?
-                        .max(I256::from(0)),
-                )?;
                 let error_tolerance = fixed!(1_000e18).mul_div_down(fixed_rate, fixed!(0.1e18));
-                let solvency =
-                    state.calculate_solvency()? + checkpoint_exposure / state.vault_share_price();
-                solvency < error_tolerance
+                state.calculate_solvency()? < error_tolerance
             };
             let is_budget_consumed = {
                 let error_tolerance = fixed!(1e18);

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -641,9 +641,17 @@ mod tests {
             let is_max_price =
                 max_spot_price - spot_price_after_long.min(max_spot_price) < fixed!(1e15);
             let is_solvency_consumed = {
-                let state = bob.get_state().await?;
+                let state = alice.get_state().await?;
+                let checkpoint_exposure = FixedPoint::try_from(
+                    alice
+                        .get_checkpoint_exposure(state.to_checkpoint(alice.now().await?))
+                        .await?
+                        .max(I256::from(0)),
+                )?;
                 let error_tolerance = fixed!(1_000e18).mul_div_down(fixed_rate, fixed!(0.1e18));
-                state.calculate_solvency()? < error_tolerance
+                let solvency =
+                    state.calculate_solvency()? + checkpoint_exposure / state.vault_share_price();
+                solvency < error_tolerance
             };
             let is_budget_consumed = {
                 let error_tolerance = fixed!(1e18);

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -329,7 +329,7 @@ impl State {
     ) -> Result<FixedPoint> {
         let checkpoint_exposure = FixedPoint::try_from(-checkpoint_exposure.min(int256!(0)))?;
         let mut estimate =
-            self.calculate_solvency() + checkpoint_exposure / self.vault_share_price();
+            self.calculate_solvency()? + checkpoint_exposure / self.vault_share_price();
         estimate = estimate.mul_div_down(self.vault_share_price(), fixed!(2e18));
         estimate /= fixed!(1e18) / estimate_price
             + self.governance_lp_fee() * self.curve_fee() * (fixed!(1e18) - spot_price)
@@ -643,7 +643,7 @@ mod tests {
             let is_solvency_consumed = {
                 let state = bob.get_state().await?;
                 let error_tolerance = fixed!(1_000e18).mul_div_down(fixed_rate, fixed!(0.1e18));
-                state.calculate_solvency() < error_tolerance
+                state.calculate_solvency()? < error_tolerance
             };
             let is_budget_consumed = {
                 let error_tolerance = fixed!(1e18);

--- a/crates/hyperdrive-math/src/long/targeted.rs
+++ b/crates/hyperdrive-math/src/long/targeted.rs
@@ -495,7 +495,7 @@ mod tests {
             // 3. IF Bob's budget is not consumed; then new rate is close to the target rate
 
             // Check that our resulting price is under the max
-            let current_state = bob.get_state().await?;
+            let current_state = alice.get_state().await?;
             let spot_price_after_long = current_state.calculate_spot_price()?;
             assert!(
                 max_spot_price_before_long > spot_price_after_long,
@@ -503,18 +503,7 @@ mod tests {
             );
 
             // Check solvency
-            let is_solvent = {
-                let state = alice.get_state().await?;
-                let checkpoint_exposure = FixedPoint::try_from(
-                    alice
-                        .get_checkpoint_exposure(state.to_checkpoint(alice.now().await?))
-                        .await?
-                        .max(I256::from(0)),
-                )?;
-                let solvency = current_state.calculate_solvency()?
-                    + checkpoint_exposure / current_state.vault_share_price();
-                solvency > allowable_solvency_error
-            };
+            let is_solvent = { current_state.calculate_solvency()? > allowable_solvency_error };
             assert!(is_solvent, "Resulting pool state is not solvent.");
 
             let new_rate = current_state.calculate_spot_rate()?;

--- a/crates/hyperdrive-math/src/long/targeted.rs
+++ b/crates/hyperdrive-math/src/long/targeted.rs
@@ -503,7 +503,7 @@ mod tests {
             );
 
             // Check solvency
-            let is_solvent = { current_state.calculate_solvency() > allowable_solvency_error };
+            let is_solvent = { current_state.calculate_solvency()? > allowable_solvency_error };
             assert!(is_solvent, "Resulting pool state is not solvent.");
 
             let new_rate = current_state.calculate_spot_rate()?;

--- a/crates/hyperdrive-math/src/long/targeted.rs
+++ b/crates/hyperdrive-math/src/long/targeted.rs
@@ -503,7 +503,18 @@ mod tests {
             );
 
             // Check solvency
-            let is_solvent = { current_state.calculate_solvency()? > allowable_solvency_error };
+            let is_solvent = {
+                let state = alice.get_state().await?;
+                let checkpoint_exposure = FixedPoint::try_from(
+                    alice
+                        .get_checkpoint_exposure(state.to_checkpoint(alice.now().await?))
+                        .await?
+                        .max(I256::from(0)),
+                )?;
+                let solvency = current_state.calculate_solvency()?
+                    + checkpoint_exposure / current_state.vault_share_price();
+                solvency > allowable_solvency_error
+            };
             assert!(is_solvent, "Resulting pool state is not solvent.");
 
             let new_rate = current_state.calculate_spot_rate()?;

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -435,10 +435,8 @@ impl State {
             FixedPoint::try_from(checkpoint_exposure.max(I256::zero()))?
                 .div_down(self.vault_share_price());
         // solvency = share_reserves - long_exposure / vault_share_price - min_share_reserves
-        let solvency = self.calculate_solvency()?;
-        let guess = self
-            .vault_share_price()
-            .mul_down(solvency + checkpoint_exposure_shares);
+        let solvency = self.calculate_solvency()? + checkpoint_exposure_shares;
+        let guess = self.vault_share_price().mul_down(solvency);
         let curve_fee = self.curve_fee().mul_down(fixed!(1e18) - spot_price);
         let gov_curve_fee = self.governance_lp_fee().mul_down(curve_fee);
         Ok(guess.div_down(spot_price - curve_fee + gov_curve_fee))

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -435,7 +435,7 @@ impl State {
             FixedPoint::try_from(checkpoint_exposure.max(I256::zero()))?
                 .div_down(self.vault_share_price());
         // solvency = share_reserves - long_exposure / vault_share_price - min_share_reserves
-        let solvency = self.calculate_solvency();
+        let solvency = self.calculate_solvency()?;
         let guess = self
             .vault_share_price()
             .mul_down(solvency + checkpoint_exposure_shares);

--- a/crates/hyperdrive-math/src/test_utils/integration_tests.rs
+++ b/crates/hyperdrive-math/src/test_utils/integration_tests.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
 
-    use ethers::types::{I256, U256};
+    use ethers::types::U256;
     use eyre::Result;
-    use fixedpointmath::{fixed, FixedPoint};
+    use fixedpointmath::fixed;
     use hyperdrive_test_utils::{chain::TestChain, constants::FUZZ_RUNS};
     use hyperdrive_wrappers::wrappers::ihyperdrive::Checkpoint;
     use rand::{thread_rng, Rng, SeedableRng};
@@ -136,14 +136,7 @@ mod tests {
                 let state = bob.get_state().await?;
                 let error_tolerance =
                     fixed!(1_000e18).mul_div_down(state.calculate_spot_rate()?, fixed!(0.1e18));
-                let checkpoint_exposure_shares = FixedPoint::try_from(
-                    alice
-                        .get_checkpoint_exposure(state.to_checkpoint(alice.now().await?))
-                        .await?
-                        .max(I256::from(0)),
-                )? / state.vault_share_price();
-                let solvency = state.calculate_solvency()? + checkpoint_exposure_shares;
-                solvency < error_tolerance
+                state.calculate_solvency()? < error_tolerance
             };
             let is_budget_consumed = {
                 let error_tolerance = fixed!(1e18);

--- a/crates/hyperdrive-math/src/test_utils/integration_tests.rs
+++ b/crates/hyperdrive-math/src/test_utils/integration_tests.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests {
 
-    use ethers::types::U256;
+    use ethers::types::{I256, U256};
     use eyre::Result;
-    use fixedpointmath::fixed;
+    use fixedpointmath::{fixed, FixedPoint};
     use hyperdrive_test_utils::{chain::TestChain, constants::FUZZ_RUNS};
     use hyperdrive_wrappers::wrappers::ihyperdrive::Checkpoint;
     use rand::{thread_rng, Rng, SeedableRng};
@@ -136,7 +136,14 @@ mod tests {
                 let state = bob.get_state().await?;
                 let error_tolerance =
                     fixed!(1_000e18).mul_div_down(state.calculate_spot_rate()?, fixed!(0.1e18));
-                state.calculate_solvency()? < error_tolerance
+                let checkpoint_exposure_shares = FixedPoint::try_from(
+                    alice
+                        .get_checkpoint_exposure(state.to_checkpoint(alice.now().await?))
+                        .await?
+                        .max(I256::from(0)),
+                )? / state.vault_share_price();
+                let solvency = state.calculate_solvency()? + checkpoint_exposure_shares;
+                solvency < error_tolerance
             };
             let is_budget_consumed = {
                 let error_tolerance = fixed!(1e18);

--- a/crates/hyperdrive-math/src/test_utils/integration_tests.rs
+++ b/crates/hyperdrive-math/src/test_utils/integration_tests.rs
@@ -136,7 +136,7 @@ mod tests {
                 let state = bob.get_state().await?;
                 let error_tolerance =
                     fixed!(1_000e18).mul_div_down(state.calculate_spot_rate()?, fixed!(0.1e18));
-                state.calculate_solvency() < error_tolerance
+                state.calculate_solvency()? < error_tolerance
             };
             let is_budget_consumed = {
                 let error_tolerance = fixed!(1e18);


### PR DESCRIPTION
# Description
- changed the `calculate_solvency` function to return a `Result<FixedPoint>` to throw a catchable error if the pool is not solvent.