### PR TITLE
Remove `_safe` fns

### DIFF
--- a/bindings/hyperdrivepy/src/hyperdrive_state_methods/yield_space.rs
+++ b/bindings/hyperdrivepy/src/hyperdrive_state_methods/yield_space.rs
@@ -36,10 +36,10 @@ impl HyperdriveState {
         })?);
         let result_fp = self
             .state
-            .calculate_shares_in_given_bonds_out_up_safe(amount_in_fp)
+            .calculate_shares_in_given_bonds_out_up(amount_in_fp)
             .map_err(|err| {
                 PyErr::new::<PyValueError, _>(format!(
-                    "Failed to execute calculate_shares_in_given_bonds_out_up_safe: {}",
+                    "Failed to execute calculate_shares_in_given_bonds_out_up: {}",
                     err
                 ))
             })?;

--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -264,10 +264,6 @@ impl State {
         calculate_effective_share_reserves(self.share_reserves(), self.share_adjustment())
     }
 
-    fn effective_share_reserves_safe(&self) -> Result<FixedPoint> {
-        calculate_effective_share_reserves_safe(self.share_reserves(), self.share_adjustment())
-    }
-
     fn bond_reserves(&self) -> FixedPoint {
         self.info.bond_reserves.into()
     }

--- a/crates/hyperdrive-math/src/lp/add.rs
+++ b/crates/hyperdrive-math/src/lp/add.rs
@@ -87,16 +87,15 @@ impl State {
             true => contribution / self.vault_share_price(),
             false => contribution,
         };
-        let (share_reserves, share_adjustment, bond_reserves) = self
-            .calculate_update_liquidity_safe(
-                self.share_reserves(),
-                self.share_adjustment(),
-                self.bond_reserves(),
-                self.minimum_share_reserves(),
-                I256::from(0),
-            )?;
+        let (share_reserves, share_adjustment, bond_reserves) = self.calculate_update_liquidity(
+            self.share_reserves(),
+            self.share_adjustment(),
+            self.bond_reserves(),
+            self.minimum_share_reserves(),
+            I256::from(0),
+        )?;
         let (new_share_reserves, new_share_adjustment, new_bond_reserves) = self
-            .calculate_update_liquidity_safe(
+            .calculate_update_liquidity(
                 self.share_reserves(),
                 self.share_adjustment(),
                 self.bond_reserves(),

--- a/crates/hyperdrive-math/src/lp/math.rs
+++ b/crates/hyperdrive-math/src/lp/math.rs
@@ -68,7 +68,7 @@ impl State {
 
     /// Calculates the resulting share_reserves, share_adjustment, and
     /// bond_reserves when updating liquidity with a `share_reserves_delta`.
-    pub fn calculate_update_liquidity_safe(
+    pub fn calculate_update_liquidity(
         &self,
         share_reserves: FixedPoint,
         share_adjustment: I256,
@@ -87,7 +87,7 @@ impl State {
         let new_share_reserves = I256::try_from(share_reserves)? + share_reserves_delta;
         if new_share_reserves < I256::try_from(minimum_share_reserves).unwrap() {
             return Err(eyre!(
-                "Update would result in share reserves below minimum."
+                "update would result in share reserves below minimum."
             ));
         }
         let new_share_reserves = FixedPoint::try_from(new_share_reserves)?;

--- a/crates/hyperdrive-math/src/lp/math.rs
+++ b/crates/hyperdrive-math/src/lp/math.rs
@@ -148,10 +148,8 @@ impl State {
             self.short_average_maturity_time(),
             current_block_timestamp,
         );
-        let net_curve_trade = self.calculate_net_curve_trade_safe(
-            long_average_time_remaining,
-            short_average_time_remaining,
-        )?;
+        let net_curve_trade = self
+            .calculate_net_curve_trade(long_average_time_remaining, short_average_time_remaining)?;
         let net_flat_trade = self
             .calculate_net_flat_trade(long_average_time_remaining, short_average_time_remaining)?;
 
@@ -166,7 +164,7 @@ impl State {
         Ok(present_value.try_into()?)
     }
 
-    pub fn calculate_net_curve_trade_safe(
+    pub fn calculate_net_curve_trade(
         &self,
         long_average_time_remaining: FixedPoint,
         short_average_time_remaining: FixedPoint,
@@ -528,7 +526,7 @@ impl State {
         // If the pool is net neutral, the initial guess is equal to the final
         // result.
         let net_curve_trade =
-            self.calculate_net_curve_trade_safe_from_timestamp(current_block_timestamp)?;
+            self.calculate_net_curve_trade_from_timestamp(current_block_timestamp)?;
         if net_curve_trade == int256!(0) {
             return Ok(share_proceeds);
         }
@@ -916,7 +914,7 @@ impl State {
         current_block_timestamp: U256,
     ) -> Result<(FixedPoint, bool)> {
         let net_curve_trade =
-            self.calculate_net_curve_trade_safe_from_timestamp(current_block_timestamp)?;
+            self.calculate_net_curve_trade_from_timestamp(current_block_timestamp)?;
         let idle = self.calculate_idle_share_reserves();
         // If the net curve position is zero or net long, then the maximum
         // share reserves delta is equal to the pool's idle.
@@ -1242,7 +1240,7 @@ mod tests {
                 state.short_average_maturity_time().into(),
                 current_block_timestamp.into(),
             );
-            let actual = state.calculate_net_curve_trade_safe(
+            let actual = state.calculate_net_curve_trade(
                 long_average_time_remaining,
                 short_average_time_remaining,
             );

--- a/crates/hyperdrive-math/src/lp/math.rs
+++ b/crates/hyperdrive-math/src/lp/math.rs
@@ -190,7 +190,7 @@ impl State {
                     self.shorts_outstanding()
                         .mul_down(short_average_time_remaining),
                 )?;
-        match self.effective_share_reserves_safe() {
+        match self.effective_share_reserves() {
             Ok(_) => {}
             // NOTE: Return 0 to indicate that the net curve trade couldn't be
             // computed.
@@ -362,7 +362,7 @@ impl State {
         // debited. If the effective share reserves or the maximum share
         // reserves delta can't be calculated or if the maximum share reserves
         // delta is zero, idle can't be distributed.
-        let success = match self.effective_share_reserves_safe() {
+        let success = match self.effective_share_reserves() {
             Ok(_) => true,
             // The error is safe from the calculation, panics are not.
             Err(_) => false,
@@ -1048,7 +1048,7 @@ impl State {
         // derivative = c * (mu * z_e(x)) ** -t_s +
         //              (y / z_e) * (y(x)) ** -t_s -
         //              (y / z_e) * (y(x) + dy) ** -t_s
-        let effective_share_reserves = self.effective_share_reserves_safe()?;
+        let effective_share_reserves = self.effective_share_reserves()?;
         // NOTE: The exponent is positive and base is flipped to handle the negative value.
         let derivative = self.vault_share_price().div_up(
             self.initial_vault_share_price()

--- a/crates/hyperdrive-math/src/lp/math.rs
+++ b/crates/hyperdrive-math/src/lp/math.rs
@@ -204,7 +204,7 @@ impl State {
             Ordering::Greater => {
                 let net_curve_position: FixedPoint = FixedPoint::try_from(net_curve_position)?;
                 let max_curve_trade =
-                    match self.calculate_max_sell_bonds_in_safe(self.minimum_share_reserves()) {
+                    match self.calculate_max_sell_bonds_in(self.minimum_share_reserves()) {
                         Ok(max_curve_trade) => max_curve_trade,
                         Err(_) => {
                             // NOTE: Return 0 to indicate that the net curve trade couldn't
@@ -214,7 +214,7 @@ impl State {
                     };
 
                 if max_curve_trade >= net_curve_position {
-                    match self.calculate_shares_out_given_bonds_in_down_safe(net_curve_position) {
+                    match self.calculate_shares_out_given_bonds_in_down(net_curve_position) {
                         Ok(net_curve_trade) => Ok(-I256::try_from(net_curve_trade)?),
                         Err(err) => {
                             // If the net curve position is smaller than the
@@ -252,7 +252,7 @@ impl State {
             }
             Ordering::Less => {
                 let net_curve_position: FixedPoint = FixedPoint::try_from(-net_curve_position)?;
-                let max_curve_trade = match self.calculate_max_buy_bonds_out_safe() {
+                let max_curve_trade = match self.calculate_max_buy_bonds_out() {
                     Ok(max_curve_trade) => max_curve_trade,
                     Err(_) => {
                         // NOTE: Return 0 to indicate that the net curve trade couldn't
@@ -261,7 +261,7 @@ impl State {
                     }
                 };
                 if max_curve_trade >= net_curve_position {
-                    match self.calculate_shares_in_given_bonds_out_up_safe(net_curve_position) {
+                    match self.calculate_shares_in_given_bonds_out_up(net_curve_position) {
                         Ok(net_curve_trade) => Ok(I256::try_from(net_curve_trade)?),
                         Err(err) => {
                             // If the net curve position is smaller than the
@@ -276,7 +276,7 @@ impl State {
                         }
                     }
                 } else {
-                    let max_share_payment = match self.calculate_max_buy_shares_in_safe() {
+                    let max_share_payment = match self.calculate_max_buy_shares_in() {
                         Ok(max_share_payment) => max_share_payment,
                         Err(_) => {
                             // NOTE: Return 0 to indicate that the net curve trade couldn't
@@ -591,7 +591,7 @@ impl State {
                 // Calculate the max bond amount. If the calculation fails, we
                 // return a failure flag.
                 let max_bond_amount = match updated_state
-                    .calculate_max_sell_bonds_in_safe(self.minimum_share_reserves())
+                    .calculate_max_sell_bonds_in(self.minimum_share_reserves())
                 {
                     Ok(max_bond_amount) => max_bond_amount,
                     // NOTE: If the max bond amount couldn't be calculated, we
@@ -638,7 +638,7 @@ impl State {
                         Err(_) => return Ok(fixed!(0)),
                     };
                     let max_bond_amount = match updated_state
-                        .calculate_max_sell_bonds_in_safe(self.minimum_share_reserves())
+                        .calculate_max_sell_bonds_in(self.minimum_share_reserves())
                     {
                         Ok(max_bond_amount) => max_bond_amount,
                         // NOTE: Return 0 to indicate that the share proceeds
@@ -928,7 +928,7 @@ impl State {
         // Calculate the max bond amount. if the calculation fails, we return a
         // failure flag. if the calculation succeeds but the max bond amount
         // is zero, then we return a failure flag since we can't divide by zero.
-        let max_bond_amount = match self.calculate_max_buy_bonds_out_safe() {
+        let max_bond_amount = match self.calculate_max_buy_bonds_out() {
             Ok(result) => result,
             // Errors are safe from the calculation, panics are not.
             Err(_) => fixed!(0),

--- a/crates/hyperdrive-math/src/lp/remove.rs
+++ b/crates/hyperdrive-math/src/lp/remove.rs
@@ -71,7 +71,7 @@ impl State {
         // withdrawal proceeds regardless of whether or not idle could be
         // distributed.
         let (_withdrawal_shares_redeemed, share_proceeds, updated_state, _success) = self
-            .distribute_excess_idle_safe(
+            .distribute_excess_idle(
                 current_block_timestamp,
                 active_lp_total_supply,
                 withdrawal_shares_total_supply,
@@ -125,7 +125,7 @@ impl State {
 
     /// Distribute as much of the excess idle as possible to the withdrawal
     /// pool while holding the LP share price constant.
-    fn distribute_excess_idle_safe(
+    fn distribute_excess_idle(
         &self,
         current_block_timestamp: U256,
         active_lp_total_supply: FixedPoint,

--- a/crates/hyperdrive-math/src/lp/remove.rs
+++ b/crates/hyperdrive-math/src/lp/remove.rs
@@ -157,7 +157,7 @@ impl State {
         )?;
 
         // Remove the withdrawal pool proceeds from the reserves.
-        match self.calculate_update_liquidity_safe(
+        match self.calculate_update_liquidity(
             self.share_reserves(),
             self.share_adjustment(),
             self.bond_reserves(),

--- a/crates/hyperdrive-math/src/lp/utils.rs
+++ b/crates/hyperdrive-math/src/lp/utils.rs
@@ -1,29 +1,13 @@
 use ethers::types::{I256, U256};
 use eyre::Result;
-use fixedpointmath::{fixed, FixedPoint};
+use fixedpointmath::fixed;
 
 use crate::State;
 
 impl State {
-    // Helper method that calculates the net curve trade.
-    pub fn calculate_net_curve_trade(
-        &self,
-        long_average_time_remaining: FixedPoint,
-        short_average_time_remaining: FixedPoint,
-    ) -> Result<I256> {
-        let net_curve_trade =
-            I256::try_from(self.longs_outstanding().mul_up(long_average_time_remaining))?
-                - I256::try_from(
-                    self.shorts_outstanding()
-                        .mul_down(short_average_time_remaining),
-                )?;
-
-        Ok(net_curve_trade)
-    }
-
     // Helper method that calculates the average time remaining for the longs
     // and shorts and the net curve trade.
-    pub fn calculate_net_curve_trade_safe_from_timestamp(
+    pub fn calculate_net_curve_trade_from_timestamp(
         &self,
         current_block_timestamp: U256,
     ) -> Result<I256> {
@@ -39,10 +23,7 @@ impl State {
             current_block_timestamp,
         );
 
-        self.calculate_net_curve_trade_safe(
-            long_average_time_remaining,
-            short_average_time_remaining,
-        )
+        self.calculate_net_curve_trade(long_average_time_remaining, short_average_time_remaining)
     }
 
     /// Calculates the result of closing the net flat position.

--- a/crates/hyperdrive-math/src/lp/utils.rs
+++ b/crates/hyperdrive-math/src/lp/utils.rs
@@ -71,7 +71,7 @@ impl State {
 
         // Calculate new reserve and adjustment levels.
         let (updated_share_reserves, updated_share_adjustment, updated_bond_reserves) = match self
-            .calculate_update_liquidity_safe(
+            .calculate_update_liquidity(
                 share_reserves,
                 share_adjustment,
                 bond_reserves,

--- a/crates/hyperdrive-math/src/short/close.rs
+++ b/crates/hyperdrive-math/src/short/close.rs
@@ -35,7 +35,7 @@ impl State {
             // payment.
             //
             let curve_bonds_in = bond_amount.mul_up(normalized_time_remaining);
-            Ok(self.calculate_shares_in_given_bonds_out_up_safe(curve_bonds_in)?)
+            Ok(self.calculate_shares_in_given_bonds_out_up(curve_bonds_in)?)
         } else {
             Ok(fixed!(0))
         }

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -227,7 +227,7 @@ impl State {
     /// \right)^{\tfrac{1}{1 - t_s}}
     /// ```
     pub fn calculate_short_principal(&self, bond_amount: FixedPoint) -> Result<FixedPoint> {
-        self.calculate_shares_out_given_bonds_in_down_safe(bond_amount)
+        self.calculate_shares_out_given_bonds_in_down(bond_amount)
     }
 
     /// Calculates the derivative of the short principal w.r.t. the amount of

--- a/crates/hyperdrive-math/src/utils.rs
+++ b/crates/hyperdrive-math/src/utils.rs
@@ -37,18 +37,9 @@ pub fn calculate_time_stretch(
         * time_stretch)
 }
 
+/// Calculates the share reserves after zeta adjustment, aka the effective share
+/// reserves: `$z_e = z - zeta$`.
 pub fn calculate_effective_share_reserves(
-    share_reserves: FixedPoint,
-    share_adjustment: I256,
-) -> Result<FixedPoint> {
-    let effective_share_reserves = I256::try_from(share_reserves)? - share_adjustment;
-    if effective_share_reserves < I256::from(0) {
-        return Err(eyre!("effective share reserves cannot be negative"));
-    }
-    effective_share_reserves.try_into()
-}
-
-pub fn calculate_effective_share_reserves_safe(
     share_reserves: FixedPoint,
     share_adjustment: I256,
 ) -> Result<FixedPoint> {


### PR DESCRIPTION
This PR cleans up dead code around the repo where we partially adhered to the safe/unsafe distinction found in Solidity Hyperdrive. My changes generally remove the "safe" keyword; the Rust developer should always assume the implementation matches the Solidity "safe" function when appropriate.

Rust can handle error messages easily via the `match` statement and `Result` type. Therefore, we do not need to differentiate between "safe" and "unsafe" function implementations. We should always implement the "safe" version with proper error handling.

This is effectively what we were doing -- most of the time we either had 1) a "safe" and no "unsafe" implementation or 2) a "safe" implementation that directly copied the "unsafe" implementation.