### PR TITLE
fix open long delta calculations and add tests

### DIFF
--- a/bindings/hyperdrivepy/python/hyperdrivepy/hyperdrive_state.py
+++ b/bindings/hyperdrivepy/python/hyperdrivepy/hyperdrive_state.py
@@ -221,7 +221,7 @@ def calculate_pool_deltas_after_open_long(
     pool_config: types.PoolConfigType,
     pool_info: types.PoolInfoType,
     base_amount: str,
-) -> str:
+) -> tuple[str, str]:
     """Calculate the bond deltas to be applied to the pool after opening a long.
 
     Arguments
@@ -237,8 +237,8 @@ def calculate_pool_deltas_after_open_long(
 
     Returns
     -------
-    str (FixedPoint)
-        The amount of bonds to remove from the pool reserves.
+    (str (FixedPoint), str (FixedPoint))
+        The (shares, bonds) deltas to apply to the pool state.
     """
     return _get_interface(pool_config, pool_info).calculate_pool_deltas_after_open_long(base_amount)
 

--- a/bindings/hyperdrivepy/src/hyperdrive_state_methods/long/open.rs
+++ b/bindings/hyperdrivepy/src/hyperdrive_state_methods/long/open.rs
@@ -23,24 +23,28 @@ impl HyperdriveState {
         Ok(result)
     }
 
-    pub fn calculate_pool_deltas_after_open_long(&self, base_amount: &str) -> PyResult<String> {
+    pub fn calculate_pool_deltas_after_open_long(
+        &self,
+        base_amount: &str,
+    ) -> PyResult<(String, String)> {
         let base_amount_fp = FixedPoint::from(U256::from_dec_str(base_amount).map_err(|err| {
             PyErr::new::<PyValueError, _>(format!(
                 "Failed to convert base_amount string {} to U256: {}",
                 base_amount, err
             ))
         })?);
-        let result_fp = self
+        let (share_result_fp, bond_result_fp) = self
             .state
-            .calculate_pool_deltas_after_open_long(base_amount_fp)
+            .calculate_pool_share_bond_deltas_after_open_long(base_amount_fp, None)
             .map_err(|err| {
                 PyErr::new::<PyValueError, _>(format!(
                     "calculate_pool_deltas_after_open_long: {:?}",
                     err
                 ))
             })?;
-        let result = U256::from(result_fp).to_string();
-        Ok(result)
+        let share_result = U256::from(share_result_fp).to_string();
+        let bond_result = U256::from(bond_result_fp).to_string();
+        Ok((share_result, bond_result))
     }
 
     pub fn calculate_spot_price_after_long(

--- a/bindings/hyperdrivepy/src/hyperdrive_state_methods/short/open.rs
+++ b/bindings/hyperdrivepy/src/hyperdrive_state_methods/short/open.rs
@@ -44,7 +44,7 @@ impl HyperdriveState {
         })?);
         let result_fp = self
             .state
-            .calculate_pool_deltas_after_open_short(bond_amount_fp)
+            .calculate_pool_share_deltas_after_open_short(bond_amount_fp)
             .map_err(|err| {
                 PyErr::new::<PyValueError, _>(format!(
                     "calculate_pool_deltas_after_open_short: {}",

--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -161,7 +161,8 @@ impl State {
 
     /// Calculates the pool reserve levels to achieve a target interest rate.
     /// This calculation does not take into account Hyperdrive's solvency
-    /// constraints or exposure and shouldn't be used directly.
+    /// constraints, share adjustments, or exposure and shouldn't be used
+    /// directly.
     ///
     /// The price for a given fixed-rate is given by
     /// `$p = \tfrac{1}{r \cdot t + 1}$`, where `$r$` is the fixed-rate and

--- a/crates/hyperdrive-math/src/long/fees.rs
+++ b/crates/hyperdrive-math/src/long/fees.rs
@@ -22,10 +22,11 @@ impl State {
             .mul_up(base_amount))
     }
 
-    /// Calculates the governance fee paid when opening longs with a given base amount.
+    /// Calculates the governance fee paid when opening longs with a given base
+    /// amount.
     ///
-    /// The open long governance fee, `$\Phi_{g,ol}(\Delta x)$`, is paid in base and
-    /// is given by:
+    /// The open long governance fee, `$\Phi_{g,ol}(\Delta x)$`, is paid in base
+    /// and is given by:
     ///
     /// ```math
     /// \Phi_{g,ol}(\Delta x) = \phi_g \cdot p \cdot \Phi_{c,ol}(\Delta x)
@@ -45,10 +46,11 @@ impl State {
             .mul_down(self.calculate_spot_price()?))
     }
 
-    /// Calculates the curve fee paid when closing longs for a given bond amount.
+    /// Calculates the curve fee paid when closing longs for a given bond
+    /// amount.
     ///
-    /// The the close long curve fee, `$\Phi_{c,cl}(\Delta y)$`, is paid in shares and
-    /// is given by:
+    /// The the close long curve fee, `$\Phi_{c,cl}(\Delta y)$`, is paid in
+    /// shares and is given by:
     ///
     /// ```math
     /// \Phi_{c,cl}(\Delta y) =

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -481,7 +481,7 @@ impl State {
         bond_amount: FixedPoint,
         checkpoint_exposure: I256,
     ) -> Result<FixedPoint> {
-        let share_deltas = self.calculate_pool_deltas_after_open_short(bond_amount)?;
+        let share_deltas = self.calculate_pool_share_deltas_after_open_short(bond_amount)?;
         if self.share_reserves() < share_deltas {
             return Err(eyre!(
                 "expected share_reserves={:#?} >= share_deltas={:#?}",

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -278,7 +278,7 @@ impl State {
     ) -> Result<Self> {
         let share_amount = match maybe_share_amount {
             Some(share_amount) => share_amount,
-            None => self.calculate_pool_deltas_after_open_short(bond_amount)?,
+            None => self.calculate_pool_share_deltas_after_open_short(bond_amount)?,
         };
         let mut state = self.clone();
         state.info.bond_reserves += bond_amount.into();
@@ -287,7 +287,7 @@ impl State {
     }
 
     /// Calculate the share deltas to be applied to the pool after opening a short.
-    pub fn calculate_pool_deltas_after_open_short(
+    pub fn calculate_pool_share_deltas_after_open_short(
         &self,
         bond_amount: FixedPoint,
     ) -> Result<FixedPoint> {
@@ -319,7 +319,7 @@ impl State {
     ) -> Result<FixedPoint> {
         let share_amount = match maybe_base_amount {
             Some(base_amount) => base_amount / self.vault_share_price(),
-            None => self.calculate_pool_deltas_after_open_short(bond_amount)?,
+            None => self.calculate_pool_share_deltas_after_open_short(bond_amount)?,
         };
         let updated_state =
             self.calculate_pool_state_after_open_short(bond_amount, Some(share_amount))?;
@@ -470,7 +470,7 @@ mod tests {
                 continue;
             }
             let bond_amount = rng.gen_range(state.minimum_transaction_amount()..=max_bond_amount);
-            let rust_pool_deltas = state.calculate_pool_deltas_after_open_short(bond_amount);
+            let rust_pool_deltas = state.calculate_pool_share_deltas_after_open_short(bond_amount);
             let curve_fee_base = state.open_short_curve_fee(bond_amount)?;
             let gov_fee_base =
                 state.open_short_governance_fee(bond_amount, Some(curve_fee_base))?;
@@ -783,7 +783,8 @@ mod tests {
             let price_with_default = state.calculate_spot_price_after_short(bond_amount, None)?;
 
             // Using a pre-calculated base amount
-            let base_amount = match state.calculate_pool_deltas_after_open_short(bond_amount) {
+            let base_amount = match state.calculate_pool_share_deltas_after_open_short(bond_amount)
+            {
                 Ok(share_amount) => Some(share_amount * state.vault_share_price()),
                 Err(_) => continue,
             };

--- a/crates/hyperdrive-math/src/utils.rs
+++ b/crates/hyperdrive-math/src/utils.rs
@@ -229,7 +229,7 @@ mod tests {
                     Ok(max_long) => max_long,
                     Err(_) => continue, // Max threw an Err. Don't finish this fuzz iteration.
                 },
-                Err(_) => continue, // Max threw a paanic. Don't finish this fuzz iteration.
+                Err(_) => continue, // Max threw a panic. Don't finish this fuzz iteration.
             };
             let min_rate = state.calculate_spot_rate_after_long(max_long, None)?;
 


### PR DESCRIPTION
# Resolved Issues
working towards https://github.com/delvtech/hyperdrive-rs/issues/171 and https://github.com/delvtech/hyperdrive-rs/issues/21

# Description
- The code for calculating pool deltas & state after opening a long did not correctly account for the gov fee's impact on the share reserves. I fixed this and added a test to demonstrate the failure
- I added a similar test on the short side, which almost passes with equality (seems there is a rounding error)
- I renamed some functions, cleaned up some comments, fixed some typos
