### PR TITLE
add python bindings for `calculate_market_value` functions

### DIFF
--- a/bindings/hyperdrivepy/python/hyperdrivepy/hyperdrive_state.py
+++ b/bindings/hyperdrivepy/python/hyperdrivepy/hyperdrive_state.py
@@ -757,6 +757,40 @@ def calculate_idle_share_reserves_in_base(
     return _get_interface(pool_config, pool_info).calculate_idle_share_reserves_in_base()
 
 
+def calculate_scaled_normalized_time_remaining(
+    pool_config: types.PoolConfigType,
+    pool_info: types.PoolInfoType,
+    scaled_maturity_time: str,
+    current_time: str,
+) -> str:
+    """Calculate the normalized time remaining with high precision.
+
+    Arguments
+    ---------
+    pool_config: PoolConfig
+        Static configuration for the hyperdrive contract.
+        Set at deploy time.
+    pool_info: PoolInfo
+        Current state information of the hyperdrive contract.
+        Includes attributes like reserve levels and share prices.
+    scaled_maturity_time: str (FixedPoint)
+        The maturity time scaled to be a FixedPoint. For example, 100 seconds
+        would be represented as FixedPoint(100) in Python or fixed!(100e18) in
+        Rust.
+    current_time: str (U256)
+        The current time as an integer. For example, 100 seconds would be 100 in
+        Python or Rust.
+
+    Returns
+    -------
+    str (FixedPoint)
+        The idle share reserves in base of the pool.
+    """
+    return _get_interface(pool_config, pool_info).calculate_scaled_normalized_time_remaining(
+        scaled_maturity_time, current_time
+    )
+
+
 def calculate_add_liquidity(
     pool_config: types.PoolConfigType,
     pool_info: types.PoolInfoType,

--- a/bindings/hyperdrivepy/python/hyperdrivepy/hyperdrive_state.py
+++ b/bindings/hyperdrivepy/python/hyperdrivepy/hyperdrive_state.py
@@ -433,7 +433,7 @@ def calculate_market_value_short(
     close_vault_share_price: str (FixedPoint)
         The share price when the short was closed.
     maturity_time: str (FixedPoint)
-        The maturity time of the long.
+        The maturity time of the short.
     current_time: str (FixedPoint)
         The current block time.
 

--- a/bindings/hyperdrivepy/python/hyperdrivepy/hyperdrive_state.py
+++ b/bindings/hyperdrivepy/python/hyperdrivepy/hyperdrive_state.py
@@ -275,6 +275,38 @@ def calculate_close_long(
     return _get_interface(pool_config, pool_info).calculate_close_long(bond_amount, maturity_time, current_time)
 
 
+def calculate_market_value_long(
+    pool_config: types.PoolConfigType,
+    pool_info: types.PoolInfoType,
+    bond_amount: str,
+    maturity_time: str,
+    current_time: str,
+) -> str:
+    """Estimates the current market value of an open long position.
+
+    Arguments
+    ---------
+    pool_config: PoolConfig
+        Static configuration for the hyperdrive contract.
+        Set at deploy time.
+    pool_info: PoolInfo
+        Current state information of the hyperdrive contract.
+        Includes attributes like reserve levels and share prices.
+    bond_amount: str (FixedPoint)
+        The amount of bonds to sell.
+    maturity_time: str (FixedPoint)
+        The maturity time of the long.
+    current_time: str (FixedPoint)
+        The current block time.
+
+    Returns
+    -------
+    str (FixedPoint)
+        An estimate of the amount of shares returned upon closing the long.
+    """
+    return _get_interface(pool_config, pool_info).calculate_market_value_long(bond_amount, maturity_time, current_time)
+
+
 def calculate_open_short(
     pool_config: types.PoolConfigType,
     pool_info: types.PoolInfoType,
@@ -371,6 +403,46 @@ def calculate_close_short(
         The amount of shares the trader will receive for closing the short.
     """
     return _get_interface(pool_config, pool_info).calculate_close_short(
+        bond_amount, open_vault_share_price, close_vault_share_price, maturity_time, current_time
+    )
+
+
+def calculate_market_value_short(
+    pool_config: types.PoolConfigType,
+    pool_info: types.PoolInfoType,
+    bond_amount: str,
+    open_vault_share_price: str,
+    close_vault_share_price: str,
+    maturity_time: str,
+    current_time: str,
+) -> str:
+    """Estimates the current market value of an open short position.
+
+    Arguments
+    ---------
+    pool_config: PoolConfig
+        Static configuration for the hyperdrive contract.
+        Set at deploy time.
+    pool_info: PoolInfo
+        Current state information of the hyperdrive contract.
+        Includes attributes like reserve levels and share prices.
+    bond_amount: str (FixedPoint)
+        The amount to of bonds provided.
+    open_vault_share_price: str (FixedPoint)
+        The share price when the short was opened.
+    close_vault_share_price: str (FixedPoint)
+        The share price when the short was closed.
+    maturity_time: str (FixedPoint)
+        The maturity time of the long.
+    current_time: str (FixedPoint)
+        The current block time.
+
+    Returns
+    -------
+    str (FixedPoint)
+        An estimate of the amount of shares returned upon closing the short.
+    """
+    return _get_interface(pool_config, pool_info).calculate_market_value_short(
         bond_amount, open_vault_share_price, close_vault_share_price, maturity_time, current_time
     )
 

--- a/bindings/hyperdrivepy/src/hyperdrive_state_methods.rs
+++ b/bindings/hyperdrivepy/src/hyperdrive_state_methods.rs
@@ -4,6 +4,7 @@ mod short;
 mod yield_space;
 
 use ethers::core::types::U256;
+use fixedpointmath::FixedPoint;
 use pyo3::{exceptions::PyValueError, prelude::*};
 
 pub use crate::utils::*;
@@ -62,6 +63,32 @@ impl HyperdriveState {
 
     pub fn calculate_idle_share_reserves_in_base(&self) -> PyResult<String> {
         let result_fp = self.state.calculate_idle_share_reserves_in_base();
+        let result = U256::from(result_fp).to_string();
+        Ok(result)
+    }
+
+    pub fn calculate_scaled_normalized_time_remaining(
+        &self,
+        scaled_maturity_time: &str,
+        current_time: &str,
+    ) -> PyResult<String> {
+        let scaled_maturity_time_fp =
+            FixedPoint::from(U256::from_dec_str(scaled_maturity_time).map_err(|err| {
+                PyErr::new::<PyValueError, _>(format!(
+                    "Failed to convert scaled_amturity_time string {} to FixedPoint: {}",
+                    scaled_maturity_time, err
+                ))
+            })?);
+
+        let current_time_int = U256::from_dec_str(current_time).map_err(|err| {
+            PyErr::new::<PyValueError, _>(format!(
+                "Failed to convert current_time string {} to U256: {}",
+                current_time, err
+            ))
+        })?;
+        let result_fp = self
+            .state
+            .calculate_scaled_normalized_time_remaining(scaled_maturity_time_fp, current_time_int);
         let result = U256::from(result_fp).to_string();
         Ok(result)
     }

--- a/bindings/hyperdrivepy/src/hyperdrive_state_methods/long/close.rs
+++ b/bindings/hyperdrivepy/src/hyperdrive_state_methods/long/close.rs
@@ -40,4 +40,39 @@ impl HyperdriveState {
         let result = U256::from(result_fp).to_string();
         Ok(result)
     }
+
+    pub fn calculate_market_value_long(
+        &self,
+        bond_amount: &str,
+        maturity_time: &str,
+        current_time: &str,
+    ) -> PyResult<String> {
+        let bond_amount_fp = FixedPoint::from(U256::from_dec_str(bond_amount).map_err(|err| {
+            PyErr::new::<PyValueError, _>(format!(
+                "Failed to convert bond_amount string {} to U256: {}",
+                bond_amount, err
+            ))
+        })?);
+        let maturity_time = U256::from_dec_str(maturity_time).map_err(|err| {
+            PyErr::new::<PyValueError, _>(format!(
+                "Failed to convert maturity_time string {} to U256: {}",
+                maturity_time, err
+            ))
+        })?;
+        let current_time = U256::from_dec_str(current_time).map_err(|err| {
+            PyErr::new::<PyValueError, _>(format!(
+                "Failed to convert current_time string {} to U256: {}",
+                current_time, err
+            ))
+        })?;
+
+        let result_fp = self
+            .state
+            .calculate_market_value_long(bond_amount_fp, maturity_time, current_time)
+            .map_err(|err| {
+                PyErr::new::<PyValueError, _>(format!("calculate_market_value_long: {}", err))
+            })?;
+        let result = U256::from(result_fp).to_string();
+        Ok(result)
+    }
 }

--- a/bindings/hyperdrivepy/src/hyperdrive_state_methods/long/close.rs
+++ b/bindings/hyperdrivepy/src/hyperdrive_state_methods/long/close.rs
@@ -53,13 +53,13 @@ impl HyperdriveState {
                 bond_amount, err
             ))
         })?);
-        let maturity_time = U256::from_dec_str(maturity_time).map_err(|err| {
+        let maturity_time_int = U256::from_dec_str(maturity_time).map_err(|err| {
             PyErr::new::<PyValueError, _>(format!(
                 "Failed to convert maturity_time string {} to U256: {}",
                 maturity_time, err
             ))
         })?;
-        let current_time = U256::from_dec_str(current_time).map_err(|err| {
+        let current_time_int = U256::from_dec_str(current_time).map_err(|err| {
             PyErr::new::<PyValueError, _>(format!(
                 "Failed to convert current_time string {} to U256: {}",
                 current_time, err
@@ -68,7 +68,7 @@ impl HyperdriveState {
 
         let result_fp = self
             .state
-            .calculate_market_value_long(bond_amount_fp, maturity_time, current_time)
+            .calculate_market_value_long(bond_amount_fp, maturity_time_int, current_time_int)
             .map_err(|err| {
                 PyErr::new::<PyValueError, _>(format!("calculate_market_value_long: {}", err))
             })?;

--- a/bindings/hyperdrivepy/src/hyperdrive_state_methods/short/close.rs
+++ b/bindings/hyperdrivepy/src/hyperdrive_state_methods/short/close.rs
@@ -90,13 +90,13 @@ impl HyperdriveState {
                     close_vault_share_price, err
                 ))
             })?);
-        let maturity_time = U256::from_dec_str(maturity_time).map_err(|err| {
+        let maturity_time_int = U256::from_dec_str(maturity_time).map_err(|err| {
             PyErr::new::<PyValueError, _>(format!(
                 "Failed to convert maturity_time string {} to U256: {}",
                 maturity_time, err
             ))
         })?;
-        let current_time = U256::from_dec_str(current_time).map_err(|err| {
+        let current_time_int = U256::from_dec_str(current_time).map_err(|err| {
             PyErr::new::<PyValueError, _>(format!(
                 "Failed to convert current_time string {} to U256: {}",
                 current_time, err
@@ -108,8 +108,8 @@ impl HyperdriveState {
                 bond_amount_fp,
                 open_vault_share_price_fp,
                 close_vault_share_price_fp,
-                maturity_time,
-                current_time,
+                maturity_time_int,
+                current_time_int,
             )
             .map_err(|err| {
                 PyErr::new::<PyValueError, _>(format!("calculate_market_value_short: {}", err))

--- a/bindings/hyperdrivepy/src/hyperdrive_state_methods/short/close.rs
+++ b/bindings/hyperdrivepy/src/hyperdrive_state_methods/short/close.rs
@@ -61,4 +61,60 @@ impl HyperdriveState {
         let result = U256::from(result_fp).to_string();
         Ok(result)
     }
+
+    pub fn calculate_market_value_short(
+        &self,
+        bond_amount: &str,
+        open_vault_share_price: &str,
+        close_vault_share_price: &str,
+        maturity_time: &str,
+        current_time: &str,
+    ) -> PyResult<String> {
+        let bond_amount_fp = FixedPoint::from(U256::from_dec_str(bond_amount).map_err(|err| {
+            PyErr::new::<PyValueError, _>(format!(
+                "Failed to convert bond_amount string {} to U256: {}",
+                bond_amount, err
+            ))
+        })?);
+        let open_vault_share_price_fp =
+            FixedPoint::from(U256::from_dec_str(open_vault_share_price).map_err(|err| {
+                PyErr::new::<PyValueError, _>(format!(
+                    "Failed to convert open_vault_share_price string {} to U256: {}",
+                    open_vault_share_price, err
+                ))
+            })?);
+        let close_vault_share_price_fp =
+            FixedPoint::from(U256::from_dec_str(close_vault_share_price).map_err(|err| {
+                PyErr::new::<PyValueError, _>(format!(
+                    "Failed to convert close_vault_share_price string {} to U256: {}",
+                    close_vault_share_price, err
+                ))
+            })?);
+        let maturity_time = U256::from_dec_str(maturity_time).map_err(|err| {
+            PyErr::new::<PyValueError, _>(format!(
+                "Failed to convert maturity_time string {} to U256: {}",
+                maturity_time, err
+            ))
+        })?;
+        let current_time = U256::from_dec_str(current_time).map_err(|err| {
+            PyErr::new::<PyValueError, _>(format!(
+                "Failed to convert current_time string {} to U256: {}",
+                current_time, err
+            ))
+        })?;
+        let result_fp = self
+            .state
+            .calculate_market_value_short(
+                bond_amount_fp,
+                open_vault_share_price_fp,
+                close_vault_share_price_fp,
+                maturity_time,
+                current_time,
+            )
+            .map_err(|err| {
+                PyErr::new::<PyValueError, _>(format!("calculate_market_value_short: {}", err))
+            })?;
+        let result = U256::from(result_fp).to_string();
+        Ok(result)
+    }
 }

--- a/bindings/hyperdrivepy/tests/wrapper_test.py
+++ b/bindings/hyperdrivepy/tests/wrapper_test.py
@@ -460,3 +460,13 @@ def test_calculate_idle_share_reserves_in_base():
     """Test calculate_idle_share_reserves_in_base."""
     idle_share_reserves = hyperdrivepy.calculate_idle_share_reserves_in_base(POOL_CONFIG, POOL_INFO)
     assert int(idle_share_reserves) > 0
+
+
+def test_calculate_scaled_normalized_time_remaining():
+    """Test calculate_scaled_normalized_time_remaining."""
+    scaled_maturity_time = str(int(100e18))
+    current_time = str(50)
+    normalized_time_remaining = hyperdrivepy.calculate_scaled_normalized_time_remaining(
+        POOL_CONFIG, POOL_INFO, scaled_maturity_time, current_time
+    )
+    assert int(normalized_time_remaining) > 0

--- a/bindings/hyperdrivepy/tests/wrapper_test.py
+++ b/bindings/hyperdrivepy/tests/wrapper_test.py
@@ -214,6 +214,17 @@ def test_calculate_close_long():
     assert int(shares_returned) > 0
 
 
+def test_calculate_market_value_long():
+    """Test for calculate_market_value_long."""
+    bond_amount = str(500 * 10**18)
+    maturity_time = str(9 * 10**17 + 10)
+    current_time = str(9 * 10**17)
+    shares_returned = hyperdrivepy.calculate_market_value_long(
+        POOL_CONFIG, POOL_INFO, bond_amount, maturity_time, current_time
+    )
+    assert int(shares_returned) > 0
+
+
 def test_calculate_open_short():
     """Test for calculate_open_short."""
     short_amount = str(50 * 10**18)
@@ -237,6 +248,25 @@ def test_calculate_close_short():
     maturity_time = str(9 * 10**17 + 10)
     current_time = str(9 * 10**17)
     shares_received = hyperdrivepy.calculate_close_short(
+        POOL_CONFIG,
+        POOL_INFO,
+        short_amount,
+        open_vault_share_price,
+        close_vault_share_price,
+        maturity_time,
+        current_time,
+    )
+    assert int(shares_received) > 0
+
+
+def test_calculate_market_value_short():
+    """Test for calculate_market_value_short."""
+    short_amount = str(50 * 10**18)
+    open_vault_share_price = str(8 * 10**17)
+    close_vault_share_price = str(9 * 10**17)
+    maturity_time = str(9 * 10**17 + 10)
+    current_time = str(9 * 10**17)
+    shares_received = hyperdrivepy.calculate_market_value_short(
         POOL_CONFIG,
         POOL_INFO,
         short_amount,


### PR DESCRIPTION
# Resolved Issues
https://github.com/delvtech/hyperdrive-rs/issues/138
https://github.com/delvtech/agent0/issues/1618

# Description
This PR adds python bindings for  `calculate_market_value_long`, `calculate_market_value_short`, and `calc_scaled_normalized_time_remaining`. 