### PR TITLE
new test for closing trades after maturity

### DIFF
--- a/crates/hyperdrive-math/src/long/close.rs
+++ b/crates/hyperdrive-math/src/long/close.rs
@@ -125,7 +125,7 @@ mod tests {
         for _ in 0..*FAST_FUZZ_RUNS {
             let state = rng.gen::<State>();
             let in_ = rng.gen_range(fixed!(0)..=state.effective_share_reserves()?);
-            let maturity_time = state.checkpoint_duration();
+            let maturity_time = state.position_duration();
             let early_time = rng.gen_range(fixed!(0)..=maturity_time);
             let base_earned_before_maturity =
                 state.calculate_close_long(in_, maturity_time.into(), early_time.into())?
@@ -166,7 +166,7 @@ mod tests {
         for _ in 0..*FAST_FUZZ_RUNS {
             let state = rng.gen::<State>();
             let in_ = rng.gen_range(fixed!(0)..=state.effective_share_reserves()?);
-            let maturity_time = state.checkpoint_duration();
+            let maturity_time = state.position_duration();
             let current_time = rng.gen_range(fixed!(0)..=maturity_time);
             let normalized_time_remaining = state
                 .calculate_normalized_time_remaining(maturity_time.into(), current_time.into());

--- a/crates/hyperdrive-math/src/long/close.rs
+++ b/crates/hyperdrive-math/src/long/close.rs
@@ -131,11 +131,6 @@ mod tests {
             // if the checkpoint_duration does not evenly divide into
             // position_duration.
             let maturity_time = state.position_duration();
-            // Close a long before it has matured.
-            let early_time = rng.gen_range(fixed!(0)..=maturity_time);
-            let base_earned_before_maturity =
-                state.calculate_close_long(in_, maturity_time.into(), early_time.into())?
-                    * state.vault_share_price();
             // Close a long just after it has matured.
             let just_after_maturity = maturity_time + state.checkpoint_duration();
             let base_earned_just_after_maturity = state.calculate_close_long(
@@ -150,13 +145,7 @@ mod tests {
                 maturity_time.into(),
                 well_after_maturity.into(),
             )? * state.vault_share_price();
-            // Check return values.
-            assert!(
-                base_earned_before_maturity <= base_earned_just_after_maturity,
-                "User lost money holding the long: earnings_before={:?} > earnings_after={:?}",
-                base_earned_before_maturity,
-                base_earned_just_after_maturity
-            );
+            // Check that no extra money was earned.
             assert!(
                 base_earned_well_after_maturity == base_earned_just_after_maturity,
                 "User should not have earned any more after maturity:
@@ -165,7 +154,6 @@ mod tests {
                 base_earned_just_after_maturity
             );
         }
-
         Ok(())
     }
 

--- a/crates/hyperdrive-math/src/long/close.rs
+++ b/crates/hyperdrive-math/src/long/close.rs
@@ -148,7 +148,7 @@ mod tests {
             // Check that no extra money was earned.
             assert!(
                 base_earned_well_after_maturity == base_earned_just_after_maturity,
-                "User should not have earned any more after maturity:
+                "Trader should not have earned any more after maturity:
                 earned_well_after_maturity={:?} != earned_just_after_maturity={:?}",
                 base_earned_well_after_maturity,
                 base_earned_just_after_maturity

--- a/crates/hyperdrive-math/src/short/close.rs
+++ b/crates/hyperdrive-math/src/short/close.rs
@@ -353,7 +353,7 @@ mod tests {
             // if the checkpoint_duration does not evenly divide into
             // position_duration.
             let maturity_time = state.position_duration();
-            // Close a lshort just after it has matured.
+            // Close a short just after it has matured.
             let just_after_maturity = maturity_time + state.checkpoint_duration();
             let base_earned_just_after_maturity = state.calculate_close_short(
                 in_,

--- a/crates/hyperdrive-math/src/short/close.rs
+++ b/crates/hyperdrive-math/src/short/close.rs
@@ -341,6 +341,49 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    async fn fuzz_calculate_close_short_after_maturity() -> Result<()> {
+        // TODO: This simulates a 0% variable rate because the vault share price
+        // does not change over time. We should write one with a positive rate.
+        let mut rng = thread_rng();
+        for _ in 0..*FAST_FUZZ_RUNS {
+            let state = rng.gen::<State>();
+            let in_ = rng.gen_range(fixed!(0)..=state.effective_share_reserves()?);
+            let open_vault_share_price = rng.gen_range(fixed!(0)..=state.vault_share_price());
+            // NOTE: The actual maturity time could be shy of position_duration
+            // if the checkpoint_duration does not evenly divide into
+            // position_duration.
+            let maturity_time = state.position_duration();
+            // Close a lshort just after it has matured.
+            let just_after_maturity = maturity_time + state.checkpoint_duration();
+            let base_earned_just_after_maturity = state.calculate_close_short(
+                in_,
+                open_vault_share_price,
+                state.vault_share_price(),
+                maturity_time.into(),
+                just_after_maturity.into(),
+            )? * state.vault_share_price();
+            // Close a short a good while after it has matured.
+            let well_after_maturity = just_after_maturity + fixed!(1e10);
+            let base_earned_well_after_maturity = state.calculate_close_short(
+                in_,
+                open_vault_share_price,
+                state.vault_share_price(),
+                maturity_time.into(),
+                well_after_maturity.into(),
+            )? * state.vault_share_price();
+            // Check that no extra money was earned.
+            assert!(
+                base_earned_well_after_maturity == base_earned_just_after_maturity,
+                "Trader should not have earned any more after maturity:
+                earned_well_after_maturity={:?} != earned_just_after_maturity={:?}",
+                base_earned_well_after_maturity,
+                base_earned_just_after_maturity
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn fuzz_sol_calculate_short_proceeds_up() -> Result<()> {
         let chain = TestChain::new().await?;
 


### PR DESCRIPTION
# Resolved Issues
https://github.com/delvtech/hyperdrive-rs/issues/197

# Description
This PR adds a test to ensure that the `calculate_close_long` and `calculate_close_short` function correctly handle proceeds going to LPs after maturity.