### PR TITLE
add `calculate_approximate_short_bonds_given_base_deposit`

### DIFF
--- a/crates/hyperdrive-math/src/test_utils/preamble.rs
+++ b/crates/hyperdrive-math/src/test_utils/preamble.rs
@@ -128,7 +128,7 @@ fn get_max_long(state: State, maybe_max_num_tries: Option<usize>) -> Result<Fixe
 }
 
 /// Conservative and safe estimate of the maximum short.
-fn get_max_short(
+pub fn get_max_short(
     state: State,
     checkpoint_exposure: I256,
     maybe_max_num_tries: Option<usize>,


### PR DESCRIPTION
# Resolved Issues
This gives us a good starting point towards resolving https://github.com/delvtech/hyperdrive-rs/issues/185

# Description
[approx_short.pdf](https://github.com/user-attachments/files/17171509/approx_short.pdf)
<img width="485" alt="image" src="https://github.com/user-attachments/assets/adc50db1-b809-4e1d-b47a-416bd578efd9">
<img width="485" alt="image" src="https://github.com/user-attachments/assets/666a55ea-0857-42d7-9f1e-b80509eddcca">
