### PR TITLE
calc abs max short guess

### DIFF
--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2024-05-02
+          toolchain: nightly
           override: true
           components: rustfmt, clippy
 

--- a/bindings/hyperdrivepy/src/hyperdrive_state_methods.rs
+++ b/bindings/hyperdrivepy/src/hyperdrive_state_methods.rs
@@ -38,7 +38,7 @@ impl HyperdriveState {
     }
 
     pub fn calculate_spot_price(&self) -> PyResult<String> {
-        let result_fp = self.state.calculate_spot_price().map_err(|err| {
+        let result_fp = self.state.calculate_spot_price_down().map_err(|err| {
             PyErr::new::<PyValueError, _>(format!("calculate_spot_price: {}", err))
         })?;
         let result = U256::from(result_fp).to_string();

--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -126,9 +126,14 @@ impl State {
         Self { config, info }
     }
 
-    /// Calculates the pool's spot price.
+    /// Calculates the pool's spot price, rounding down.
     pub fn calculate_spot_price_down(&self) -> Result<FixedPoint<U256>> {
         YieldSpace::calculate_spot_price_down(self)
+    }
+
+    /// Calculates the pool's spot price, rounding up.
+    pub fn calculate_spot_price_up(&self) -> Result<FixedPoint<U256>> {
+        YieldSpace::calculate_spot_price_up(self)
     }
 
     /// Calculate the pool's current spot (aka "fixed") rate.

--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -127,14 +127,14 @@ impl State {
     }
 
     /// Calculates the pool's spot price.
-    pub fn calculate_spot_price(&self) -> Result<FixedPoint<U256>> {
-        YieldSpace::calculate_spot_price(self)
+    pub fn calculate_spot_price_down(&self) -> Result<FixedPoint<U256>> {
+        YieldSpace::calculate_spot_price_down(self)
     }
 
     /// Calculate the pool's current spot (aka "fixed") rate.
     pub fn calculate_spot_rate(&self) -> Result<FixedPoint<U256>> {
         Ok(calculate_rate_given_fixed_price(
-            self.calculate_spot_price()?,
+            self.calculate_spot_price_down()?,
             self.position_duration(),
         ))
     }
@@ -364,8 +364,8 @@ mod tests {
             state.info.shorts_outstanding = uint256!(0);
             state.info.short_average_maturity_time = uint256!(0);
             // Make sure we're still solvent
-            if state.calculate_spot_price()? < state.calculate_min_spot_price()?
-                || state.calculate_spot_price()? > fixed!(1e18)
+            if state.calculate_spot_price_down()? < state.calculate_min_spot_price()?
+                || state.calculate_spot_price_down()? > fixed!(1e18)
                 || state.calculate_solvency().is_err()
             {
                 continue;
@@ -403,7 +403,7 @@ mod tests {
             new_state.info.share_reserves = target_share_reserves.into();
             new_state.info.bond_reserves = target_bond_reserves.into();
             if new_state.calculate_solvency().is_err()
-                || new_state.calculate_spot_price()? > fixed!(1e18)
+                || new_state.calculate_spot_price_down()? > fixed!(1e18)
             {
                 continue;
             }

--- a/crates/hyperdrive-math/src/long/close.rs
+++ b/crates/hyperdrive-math/src/long/close.rs
@@ -82,7 +82,7 @@ impl State {
     ) -> Result<FixedPoint<U256>> {
         let bond_amount = bond_amount.into();
 
-        let spot_price = self.calculate_spot_price()?;
+        let spot_price = self.calculate_spot_price_down()?;
         if spot_price > fixed!(1e18) {
             return Err(eyre!("Negative fixed interest!"));
         }
@@ -231,7 +231,7 @@ mod tests {
             // Ensure curve_fee is smaller than spot_price to avoid overflows
             // on the hyperdrive valuation, as that'd mean having to pay a larger
             // amount of fees than the current value of the long.
-            let spot_price = state.calculate_spot_price()?;
+            let spot_price = state.calculate_spot_price_down()?;
             if state.curve_fee() * (fixed!(1e18) - spot_price) > spot_price {
                 continue;
             }

--- a/crates/hyperdrive-math/src/long/fees.rs
+++ b/crates/hyperdrive-math/src/long/fees.rs
@@ -18,7 +18,7 @@ impl State {
         // NOTE: Round up to overestimate the curve fee.
         Ok(self
             .curve_fee()
-            .mul_up(fixed!(1e18).div_up(self.calculate_spot_price()?) - fixed!(1e18))
+            .mul_up(fixed!(1e18).div_up(self.calculate_spot_price_down()?) - fixed!(1e18))
             .mul_up(base_amount))
     }
 
@@ -43,7 +43,7 @@ impl State {
         // NOTE: Round down to underestimate the governance curve fee.
         Ok(curve_fee
             .mul_down(self.governance_lp_fee())
-            .mul_down(self.calculate_spot_price()?))
+            .mul_down(self.calculate_spot_price_down()?))
     }
 
     /// Calculates the curve fee paid when closing longs for a given bond
@@ -69,7 +69,7 @@ impl State {
         // NOTE: Round up to overestimate the curve fee.
         Ok(self
             .curve_fee()
-            .mul_up(fixed!(1e18) - self.calculate_spot_price()?)
+            .mul_up(fixed!(1e18) - self.calculate_spot_price_down()?)
             .mul_up(bond_amount)
             .mul_div_up(normalized_time_remaining, self.vault_share_price()))
     }

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -208,7 +208,8 @@ impl State {
                         + self
                             .curve_fee()
                             .mul_up(
-                                fixed!(1e18).div_up(self.calculate_spot_price_down()?) - fixed!(1e18),
+                                fixed!(1e18).div_up(self.calculate_spot_price_down()?)
+                                    - fixed!(1e18),
                             )
                             .mul_up(fixed!(1e18) - self.flat_fee()))
                     .div_up(fixed!(1e18) - self.flat_fee()))

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -104,7 +104,7 @@ impl State {
 
         // Finish computing the derivative.
         derivative -=
-            self.curve_fee() * ((fixed!(1e18) / self.calculate_spot_price()?) - fixed!(1e18));
+            self.curve_fee() * ((fixed!(1e18) / self.calculate_spot_price_down()?) - fixed!(1e18));
 
         Ok(derivative)
     }
@@ -155,7 +155,7 @@ impl State {
     ) -> Result<FixedPoint<U256>> {
         let state =
             self.calculate_pool_state_after_open_long(base_amount, maybe_bond_pool_delta)?;
-        state.calculate_spot_price()
+        state.calculate_spot_price_down()
     }
 
     /// Calculate the spot rate after a long has been opened.
@@ -336,7 +336,7 @@ mod tests {
             // Verify that the predicted spot price is equal to the ending spot
             // price. These won't be exactly equal because the vault share price
             // increases between the prediction and opening the long.
-            let actual_spot_price = bob.get_state().await?.calculate_spot_price()?;
+            let actual_spot_price = bob.get_state().await?.calculate_spot_price_down()?;
             let delta = if actual_spot_price > expected_spot_price {
                 actual_spot_price - expected_spot_price
             } else {

--- a/crates/hyperdrive-math/src/long/targeted.rs
+++ b/crates/hyperdrive-math/src/long/targeted.rs
@@ -299,7 +299,7 @@ impl State {
         // g'(x) = \phi_g \phi_c (1 - p_0)
         let gov_fee_derivative = self.governance_lp_fee()
             * self.curve_fee()
-            * (fixed!(1e18) - self.calculate_spot_price()?);
+            * (fixed!(1e18) - self.calculate_spot_price_down()?);
 
         // a(x) = mu * (z_{e,0} + 1/c (x - g(x))
         let inner_numerator = self.mu()
@@ -401,7 +401,7 @@ impl State {
         }
         let share_delta = ending_share_reserves - self.share_reserves();
         let fees = fixed!(1e18)
-            - (fixed!(1e18) - self.calculate_spot_price()?)
+            - (fixed!(1e18) - self.calculate_spot_price_down()?)
                 * self.curve_fee()
                 * self.governance_lp_fee();
         let base_delta = self.vault_share_price().mul_div_down(share_delta, fees);
@@ -620,7 +620,7 @@ mod tests {
 
             // Check that our resulting price is under the max
             let current_state = alice.get_state().await?;
-            let spot_price_after_long = current_state.calculate_spot_price()?;
+            let spot_price_after_long = current_state.calculate_spot_price_down()?;
             assert!(
                 max_spot_price_before_long > spot_price_after_long,
                 "Resulting price is greater than the max."

--- a/crates/hyperdrive-math/src/short/close.rs
+++ b/crates/hyperdrive-math/src/short/close.rs
@@ -194,7 +194,7 @@ impl State {
         Ok(fixed!(1e18)
             - self
                 .curve_fee()
-                .mul_up(fixed!(1e18) - self.calculate_spot_price()?))
+                .mul_up(fixed!(1e18) - self.calculate_spot_price_down()?))
     }
 
     /// Calculates the amount of shares the trader will receive after fees for closing a short
@@ -224,7 +224,7 @@ impl State {
             let mut state: State = self.clone();
             state.info.bond_reserves -= bond_reserves_delta.into();
             state.info.share_reserves += share_curve_delta.into();
-            state.calculate_spot_price()?
+            state.calculate_spot_price_down()?
         };
         let max_spot_price = self.calculate_close_short_max_spot_price()?;
         if short_curve_spot_price > max_spot_price {
@@ -244,7 +244,7 @@ impl State {
             let mut state: State = self.clone();
             state.info.bond_reserves -= bond_reserves_delta.into();
             state.info.share_reserves += share_curve_delta_with_fees.into();
-            state.calculate_spot_price()?
+            state.calculate_spot_price_down()?
         };
         if share_curve_delta_with_fees_spot_price > fixed!(1e18) {
             return Err(eyre!("InsufficientLiquidity: Negative Interest"));
@@ -293,7 +293,7 @@ impl State {
         let open_vault_share_price = open_vault_share_price.into();
         let close_vault_share_price = close_vault_share_price.into();
 
-        let spot_price = self.calculate_spot_price()?;
+        let spot_price = self.calculate_spot_price_down()?;
         if spot_price > fixed!(1e18) {
             return Err(eyre!("Negative fixed interest!"));
         }
@@ -513,7 +513,7 @@ mod tests {
         let state = rng.gen::<State>();
         let result = state.calculate_close_short(
             (state.config.minimum_transaction_amount - 10).into(),
-            state.calculate_spot_price()?,
+            state.calculate_spot_price_down()?,
             state.vault_share_price(),
             0.into(),
             0.into(),

--- a/crates/hyperdrive-math/src/short/fees.rs
+++ b/crates/hyperdrive-math/src/short/fees.rs
@@ -17,7 +17,7 @@ impl State {
         // NOTE: Round up to overestimate the curve fee.
         Ok(self
             .curve_fee()
-            .mul_up(fixed!(1e18) - self.calculate_spot_price()?)
+            .mul_up(fixed!(1e18) - self.calculate_spot_price_down()?)
             .mul_up(bond_amount))
     }
 
@@ -65,7 +65,7 @@ impl State {
         // NOTE: Round up to overestimate the curve fee.
         Ok(self
             .curve_fee()
-            .mul_up(fixed!(1e18) - self.calculate_spot_price()?)
+            .mul_up(fixed!(1e18) - self.calculate_spot_price_down()?)
             .mul_up(bond_amount)
             .mul_div_up(normalized_time_remaining, self.vault_share_price()))
     }

--- a/crates/hyperdrive-math/src/short/fees.rs
+++ b/crates/hyperdrive-math/src/short/fees.rs
@@ -43,6 +43,21 @@ impl State {
         Ok(curve_fee.mul_down(self.governance_lp_fee()))
     }
 
+    /// Calculate the total fees to be removed from the short principal when
+    /// opening a short for a given bond amount.
+    pub fn calculate_open_short_total_fee_shares(
+        &self,
+        bond_amount: FixedPoint<U256>,
+    ) -> Result<FixedPoint<U256>> {
+        let curve_fee_base = self.open_short_curve_fee(bond_amount)?;
+        let curve_fee_shares = curve_fee_base.div_up(self.vault_share_price());
+        let gov_curve_fee_shares = self
+            .open_short_governance_fee(bond_amount, Some(curve_fee_base))?
+            .div_up(self.vault_share_price());
+        let total_fee_shares = curve_fee_shares - gov_curve_fee_shares;
+        Ok(total_fee_shares)
+    }
+
     /// Calculates the curve fee paid when opening shorts with a given bond
     /// amount.
     ///

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -104,7 +104,7 @@ impl State {
             let base_amount_derivative = self.calculate_open_short_derivative(
                 last_good_bond_amount,
                 open_vault_share_price,
-                Some(self.calculate_spot_price()?),
+                Some(self.calculate_spot_price_down()?),
             )?;
             let dy = loss.div_up(base_amount_derivative); // div up to discourage dy == 0
 
@@ -240,7 +240,7 @@ impl State {
         // Assuming the budget is infinite, find the largest possible short that
         // can be opened. If the short satisfies the budget, this is the max
         // short amount.
-        let spot_price = self.calculate_spot_price()?;
+        let spot_price = self.calculate_spot_price_down()?;
         // The initial guess should be guaranteed correct, and we should only
         // get better from there.
         let absolute_max_bond_amount = self.calculate_absolute_max_short(
@@ -735,7 +735,7 @@ mod tests {
             // Likely: fix absolute max short such that the output is guaranteed to be solvent.
             match panic::catch_unwind(|| {
                 state.calculate_absolute_max_short(
-                    state.calculate_spot_price()?,
+                    state.calculate_spot_price_down()?,
                     checkpoint_exposure,
                     Some(max_iterations),
                 )
@@ -854,8 +854,10 @@ mod tests {
             }
 
             // Compute the guess, check that it is solvent.
-            let max_short_guess = state
-                .absolute_max_short_guess(state.calculate_spot_price()?, checkpoint_exposure)?;
+            let max_short_guess = state.absolute_max_short_guess(
+                state.calculate_spot_price_down()?,
+                checkpoint_exposure,
+            )?;
             let solvency = state.solvency_after_short(max_short_guess, checkpoint_exposure)?;
 
             // Check that the remaining available shares in the pool are below a tolerance.
@@ -898,7 +900,7 @@ mod tests {
             // We need to catch panics because of overflows.
             let rust_max_bond_amount = panic::catch_unwind(|| {
                 state.calculate_absolute_max_short(
-                    state.calculate_spot_price()?,
+                    state.calculate_spot_price_down()?,
                     checkpoint_exposure,
                     Some(max_iterations),
                 )
@@ -1015,7 +1017,7 @@ mod tests {
                 .await?;
 
             let global_max_short_bonds = state.calculate_absolute_max_short(
-                state.calculate_spot_price()?,
+                state.calculate_spot_price_down()?,
                 checkpoint_exposure,
                 None,
             )?;
@@ -1126,7 +1128,7 @@ mod tests {
                     // Solidity reports everything is good, so we run the Rust fns.
                     let rust_max_bonds = panic::catch_unwind(|| {
                         state.calculate_absolute_max_short(
-                            state.calculate_spot_price()?,
+                            state.calculate_spot_price_down()?,
                             checkpoint_exposure,
                             Some(max_iterations),
                         )
@@ -1244,7 +1246,7 @@ mod tests {
                     // Solidity reports everything is good, so we run the Rust fns.
                     let rust_max_bonds = panic::catch_unwind(|| {
                         state.calculate_absolute_max_short(
-                            state.calculate_spot_price()?,
+                            state.calculate_spot_price_down()?,
                             checkpoint_exposure,
                             Some(max_iterations),
                         )

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -903,7 +903,7 @@ mod tests {
 
             let min_share_reserves = state.calculate_min_share_reserves(checkpoint_exposure)?;
 
-            // Make sure a short is possible.
+            // Check that a short is possible.
             if state
                 .effective_share_reserves()?
                 .min(state.share_reserves())
@@ -992,6 +992,9 @@ mod tests {
             if state.effective_share_reserves()?
                 < state.calculate_min_share_reserves(checkpoint_exposure)?
             {
+                chain.revert(id).await?;
+                alice.reset(Default::default()).await?;
+                // Don't need to reset bob because he hasn't done anything.
                 continue;
             }
 
@@ -1110,6 +1113,10 @@ mod tests {
                     if state.effective_share_reserves()?
                         < state.calculate_min_share_reserves(checkpoint_exposure)?
                     {
+                        chain.revert(id).await?;
+                        alice.reset(Default::default()).await?;
+                        bob.reset(Default::default()).await?;
+                        celine.reset(Default::default()).await?;
                         continue;
                     }
 

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -531,7 +531,7 @@ impl State {
         //
         // The guess that we make is very important in determining how quickly
         // we converge to the solution.
-        let mut max_bond_guess = self.absolute_max_short_guess(spot_price, checkpoint_exposure)?;
+        let mut max_bond_guess = self.absolute_max_short_guess(checkpoint_exposure)?;
         // If the initial guess is insolvent, we need to throw an error.
         let mut solvency = self.solvency_after_short(max_bond_guess, checkpoint_exposure)?;
         for _ in 0..maybe_max_iterations.unwrap_or(7) {
@@ -612,7 +612,7 @@ impl State {
         if self.effective_share_reserves()? < min_share_reserves {
             return Err(eyre!(
                 "Current effective pool share reserves = {:#?} are below the minimum = {:#?}.",
-                self.effective_share_reserves(),
+                self.effective_share_reserves()?,
                 min_share_reserves
             ));
         }
@@ -928,96 +928,6 @@ mod tests {
             );
         }
 
-        Ok(())
-    }
-
-    /// This test differentially fuzzes the `calculate_max_short` function against
-    /// the Solidity analogue `calculateMaxShort`. `calculateMaxShort` doesn't take
-    /// a trader's budget into account, so it only provides a subset of
-    /// `calculate_max_short`'s functionality. With this in mind, we provide
-    /// `calculate_max_short` with a budget of `U256::MAX` to ensure that the two
-    /// functions are equivalent.
-    #[tokio::test]
-    async fn fuzz_calculate_absolute_max_short() -> Result<()> {
-        // TODO: We should be able to pass these tests with a much lower (if not zero) tolerance.
-        let sol_correctness_tolerance = fixed!(1e17);
-
-        // Fuzz the rust and solidity implementations against each other.
-        let chain = TestChain::new().await?;
-        let mut rng = thread_rng();
-        for _ in 0..*FAST_FUZZ_RUNS {
-            let state = rng.gen::<State>();
-            let checkpoint_exposure = {
-                let value = rng.gen_range(fixed!(0)..=FixedPoint::from(U256::from(U128::MAX)));
-                if rng.gen() {
-                    -I256::try_from(value)?
-                } else {
-                    I256::try_from(value)?
-                }
-            };
-            let max_iterations = 7;
-            // We need to catch panics because of overflows.
-            let rust_max_bond_amount = panic::catch_unwind(|| {
-                state.calculate_absolute_max_short(
-                    state.calculate_spot_price_down()?,
-                    checkpoint_exposure,
-                    Some(max_iterations),
-                )
-            });
-            // Run the solidity function & compare outputs.
-            match chain
-                .mock_hyperdrive_math()
-                .calculate_max_short(
-                    MaxTradeParams {
-                        share_reserves: state.info.share_reserves,
-                        bond_reserves: state.info.bond_reserves,
-                        longs_outstanding: state.info.longs_outstanding,
-                        long_exposure: state.info.long_exposure,
-                        share_adjustment: state.info.share_adjustment,
-                        time_stretch: state.config.time_stretch,
-                        vault_share_price: state.info.vault_share_price,
-                        initial_vault_share_price: state.config.initial_vault_share_price,
-                        minimum_share_reserves: state.config.minimum_share_reserves,
-                        curve_fee: state.config.fees.curve,
-                        flat_fee: state.config.fees.flat,
-                        governance_lp_fee: state.config.fees.governance_lp,
-                    },
-                    checkpoint_exposure,
-                    max_iterations.into(),
-                )
-                .call()
-                .await
-            {
-                Ok(sol_max_bond_amount) => {
-                    // Make sure the solidity & rust runctions gave the same value.
-                    let rust_max_bonds_unwrapped = rust_max_bond_amount.unwrap().unwrap();
-                    let sol_max_bonds_fp = FixedPoint::from(sol_max_bond_amount);
-                    let error = if sol_max_bonds_fp > rust_max_bonds_unwrapped {
-                        sol_max_bonds_fp - rust_max_bonds_unwrapped
-                    } else {
-                        rust_max_bonds_unwrapped - sol_max_bonds_fp
-                    };
-                    assert!(
-                        error < sol_correctness_tolerance,
-                        "expected abs(solidity_amount={} - rust_amount={})={} < tolerance={}",
-                        sol_max_bonds_fp,
-                        rust_max_bonds_unwrapped,
-                        error,
-                        sol_correctness_tolerance,
-                    );
-                }
-                // Hyperdrive Solidity calculate_max_short threw an error
-                Err(sol_err) => {
-                    assert!(
-                        rust_max_bond_amount.is_err()
-                            || rust_max_bond_amount.as_ref().unwrap().is_err(),
-                        "expected rust_max_short={:#?} to have an error.\nsolidity error={:#?}",
-                        rust_max_bond_amount,
-                        sol_err
-                    );
-                }
-            };
-        }
         Ok(())
     }
 

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -541,6 +541,10 @@ mod tests {
             if original_state.effective_share_reserves()?
                 < original_state.calculate_min_share_reserves(checkpoint_exposure)?
             {
+                chain.revert(id).await?;
+                alice.reset(Default::default()).await?;
+                bob.reset(Default::default()).await?;
+                celine.reset(Default::default()).await?;
                 continue;
             }
 
@@ -880,6 +884,9 @@ mod tests {
             if state.effective_share_reserves()?
                 < state.calculate_min_share_reserves(checkpoint_exposure)?
             {
+                chain.revert(id).await?;
+                alice.reset(Default::default()).await?;
+                bob.reset(Default::default()).await?;
                 continue;
             }
 
@@ -1022,6 +1029,9 @@ mod tests {
             if state.effective_share_reserves()?
                 < state.calculate_min_share_reserves(checkpoint_exposure)?
             {
+                chain.revert(id).await?;
+                alice.reset(Default::default()).await?;
+                bob.reset(Default::default()).await?;
                 continue;
             }
 
@@ -1193,6 +1203,10 @@ mod tests {
             if state.effective_share_reserves()?
                 < state.calculate_min_share_reserves(checkpoint_exposure)?
             {
+                chain.revert(id).await?;
+                alice.reset(Default::default()).await?;
+                bob.reset(Default::default()).await?;
+                celine.reset(Default::default()).await?;
                 continue;
             }
 

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -314,23 +314,19 @@ impl State {
         &self,
         bond_amount: FixedPoint<U256>,
     ) -> Result<FixedPoint<U256>> {
-        let curve_fee_base = self.open_short_curve_fee(bond_amount)?;
-        let curve_fee_shares = curve_fee_base.div_up(self.vault_share_price());
-        let gov_curve_fee_shares = self
-            .open_short_governance_fee(bond_amount, Some(curve_fee_base))?
-            .div_up(self.vault_share_price());
+        let total_fee_shares = self.calculate_open_short_total_fee_shares(bond_amount)?;
         let short_principal = self.calculate_short_principal(bond_amount)?;
         if short_principal.mul_up(self.vault_share_price()) > bond_amount {
             return Err(eyre!("InsufficientLiquidity: Negative Interest"));
         }
-        if short_principal < (curve_fee_shares - gov_curve_fee_shares) {
+        if short_principal < total_fee_shares {
             return Err(eyre!(
                 "short_principal={:#?} is too low to account for fees={:#?}",
                 short_principal,
-                curve_fee_shares - gov_curve_fee_shares
+                total_fee_shares
             ));
         }
-        Ok(short_principal - (curve_fee_shares - gov_curve_fee_shares))
+        Ok(short_principal - total_fee_shares)
     }
 
     /// Calculates the spot price after opening a short.

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -274,6 +274,14 @@ impl State {
     /// the reserves are updated such that
     /// `state.bond_reserves += bond_amount` and
     /// `state.share_reserves -= share_amount`.
+    ///
+    /// The pool shares delta is the initial amount minus the short principal
+    /// minus the curve fee, or:
+    ///     ∆z = z0 - z_sp - ø_c,
+    /// from calculate_pool_share_delta_after_open_short:
+    ///     z1 = z0 - ∆z
+    /// therefore,
+    ///     z1 = z0 - (z0 - z_sp - ø_c) = z_sp + ø_c
     pub fn calculate_pool_state_after_open_short(
         &self,
         bond_amount: FixedPoint<U256>,
@@ -289,7 +297,8 @@ impl State {
         Ok(state)
     }
 
-    /// Calculates the share delta to be applied to the pool after opening a short.
+    /// Calculates the share delta to be applied to the pool after opening a
+    /// short.
     ///
     /// The share delta is given by:
     ///

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -195,7 +195,7 @@ impl State {
 
         let spot_price = match maybe_initial_spot_price {
             Some(spot_price) => spot_price,
-            None => self.calculate_spot_price()?,
+            None => self.calculate_spot_price_down()?,
         };
 
         // All of these are in base.
@@ -346,7 +346,7 @@ impl State {
         };
         let updated_state =
             self.calculate_pool_state_after_open_short(bond_amount, Some(share_amount))?;
-        updated_state.calculate_spot_price()
+        updated_state.calculate_spot_price_down()
     }
 
     /// Calculate the spot rate after a short has been opened.
@@ -475,7 +475,7 @@ impl State {
             self.calculate_short_principal(self.minimum_transaction_amount())?;
         let price_adjustment_with_fees = close_vault_share_price / open_vault_share_price
             + self.flat_fee()
-            + self.curve_fee() * (fixed!(1e18) - self.calculate_spot_price()?);
+            + self.curve_fee() * (fixed!(1e18) - self.calculate_spot_price_down()?);
         let approximate_bond_amount = (self.vault_share_price() / price_adjustment_with_fees)
             * (shares_deposit + minimum_short_principal);
         Ok(approximate_bond_amount)
@@ -617,7 +617,7 @@ mod tests {
             // We need to catch panics because of overflows.
             let max_bond_amount = match panic::catch_unwind(|| {
                 state.calculate_absolute_max_short(
-                    state.calculate_spot_price()?,
+                    state.calculate_spot_price_down()?,
                     checkpoint_exposure,
                     None,
                 )
@@ -809,7 +809,7 @@ mod tests {
             let short_deposit_derivative = state.calculate_open_short_derivative(
                 bond_amount,
                 state.vault_share_price(),
-                Some(state.calculate_spot_price()?),
+                Some(state.calculate_spot_price_down()?),
             )?;
 
             // Ensure that the empirical and analytical derivatives match.
@@ -880,7 +880,7 @@ mod tests {
             // Verify that the predicted spot price is equal to the ending spot
             // price.
             let expected_spot_price = state.calculate_spot_price_after_short(bond_amount, None)?;
-            let actual_spot_price = new_state.calculate_spot_price()?;
+            let actual_spot_price = new_state.calculate_spot_price_down()?;
             let abs_spot_price_diff = if actual_spot_price >= expected_spot_price {
                 actual_spot_price - expected_spot_price
             } else {
@@ -922,7 +922,7 @@ mod tests {
             // We need to catch panics because of overflows.
             let max_bond_amount = match panic::catch_unwind(|| {
                 state.calculate_absolute_max_short(
-                    state.calculate_spot_price()?,
+                    state.calculate_spot_price_down()?,
                     checkpoint_exposure,
                     Some(3),
                 )
@@ -1082,7 +1082,7 @@ mod tests {
             // We need to catch panics because of FixedPoint<U256> overflows & underflows.
             let max_trade = panic::catch_unwind(|| {
                 state.calculate_absolute_max_short(
-                    state.calculate_spot_price()?,
+                    state.calculate_spot_price_down()?,
                     checkpoint_exposure,
                     Some(max_iterations),
                 )

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -289,7 +289,27 @@ impl State {
         Ok(state)
     }
 
-    /// Calculate the share delta to be applied to the pool after opening a short.
+    /// Calculates the share delta to be applied to the pool after opening a short.
+    ///
+    /// The share delta is given by:
+    ///
+    /// ```math
+    /// \Delta z =
+    ///     P_{\text{lp}}(\Delta y)
+    ///     - \left( \frac{\Phi_{c,os}(\Delta y)}{c}
+    ///     - \frac{\Phi_{g,os}(\Delta y)}{c} \right)
+    /// ```
+    ///
+    /// Using the definitions of `$P_{\text{lp}}(\Delta y)`$,
+    /// `$\Phi_{c,os}(\Delta y)$`, and `$\Phi_{g,os}(\Delta y)$`:
+    ///
+    /// ```math
+    /// \Delta z = z
+    ///     - \frac{1}{\mu} \cdot \left(
+    ///     \frac{\mu}{c} \cdot (k - (y + \Delta y)^{1 - t_s})
+    ///     \right)^{\frac{1}{1 - t_s}}
+    ///     - \frac{\phi_c \cdot (1 - p) \cdot \Delta y \cdot (1 - \phi_g)}{c}
+    /// ```
     pub fn calculate_pool_share_delta_after_open_short(
         &self,
         bond_amount: FixedPoint<U256>,

--- a/crates/hyperdrive-math/src/test_utils/agent.rs
+++ b/crates/hyperdrive-math/src/test_utils/agent.rs
@@ -98,7 +98,7 @@ impl HyperdriveMathAgent for Agent<ChainClient<LocalWallet>, ChaCha8Rng> {
     }
     /// Calculates the spot price.
     async fn calculate_spot_price(&self) -> Result<FixedPoint<U256>> {
-        self.get_state().await?.calculate_spot_price()
+        self.get_state().await?.calculate_spot_price_down()
     }
 
     /// Calculates the long amount that will be opened for a given base amount.
@@ -190,7 +190,7 @@ impl HyperdriveMathAgent for Agent<ChainClient<LocalWallet>, ChaCha8Rng> {
             // weighted average of the spot price and the minimum possible
             // spot price the pool can quote. We choose the weights so that this
             // is an underestimate of the worst case realized price.
-            let spot_price = state.calculate_spot_price()?;
+            let spot_price = state.calculate_spot_price_down()?;
             let min_price = state.calculate_min_spot_price()?;
 
             // Calculate the linear interpolation.

--- a/crates/hyperdrive-math/src/test_utils/preamble.rs
+++ b/crates/hyperdrive-math/src/test_utils/preamble.rs
@@ -72,12 +72,7 @@ pub async fn initialize_pool_with_random_state(
 
     // Add some liquidity again to make sure future bots can make trades.
     let liquidity_amount = rng.gen_range(fixed!(1_000e18)..=fixed!(100_000_000e18));
-    let exposure = FixedPoint::try_from(
-        alice
-            .get_checkpoint_exposure(alice.latest_checkpoint().await?)
-            .await?
-            .max(I256::zero()),
-    )? + alice.get_state().await?.long_exposure();
+    let exposure = alice.get_state().await?.long_exposure();
     alice.fund(liquidity_amount + exposure).await?;
     alice
         .add_liquidity(liquidity_amount + exposure, None)

--- a/crates/hyperdrive-math/src/test_utils/preamble.rs
+++ b/crates/hyperdrive-math/src/test_utils/preamble.rs
@@ -72,8 +72,16 @@ pub async fn initialize_pool_with_random_state(
 
     // Add some liquidity again to make sure future bots can make trades.
     let liquidity_amount = rng.gen_range(fixed!(1_000e18)..=fixed!(100_000_000e18));
-    alice.fund(liquidity_amount).await?;
-    alice.add_liquidity(liquidity_amount, None).await?;
+    let exposure = FixedPoint::try_from(
+        alice
+            .get_checkpoint_exposure(alice.latest_checkpoint().await?)
+            .await?
+            .max(I256::zero()),
+    )? + alice.get_state().await?.long_exposure();
+    alice.fund(liquidity_amount + exposure).await?;
+    alice
+        .add_liquidity(liquidity_amount + exposure, None)
+        .await?;
 
     Ok(())
 }

--- a/crates/hyperdrive-math/src/test_utils/preamble.rs
+++ b/crates/hyperdrive-math/src/test_utils/preamble.rs
@@ -91,9 +91,9 @@ fn get_max_long(state: State, maybe_max_num_tries: Option<usize>) -> Result<Fixe
     }) {
         Ok(max_long_no_panic) => match max_long_no_panic {
             Ok(max_long_no_err) => max_long_no_err,
-            Err(_) => state.bond_reserves() * state.calculate_spot_price()? * fixed!(10e18),
+            Err(_) => state.bond_reserves() * state.calculate_spot_price_down()? * fixed!(10e18),
         },
-        Err(_) => state.bond_reserves() * state.calculate_spot_price()? * fixed!(10e18),
+        Err(_) => state.bond_reserves() * state.calculate_spot_price_down()? * fixed!(10e18),
     };
 
     let mut num_tries = 0;
@@ -143,7 +143,7 @@ pub fn get_max_short(
         // weighted average of the spot price and the minimum possible
         // spot price the pool can quote. We choose the weights so that this
         // is an underestimate of the worst case realized price.
-        let spot_price = state.calculate_spot_price()?;
+        let spot_price = state.calculate_spot_price_down()?;
         let min_price = state.calculate_min_spot_price()?;
 
         // Calculate the linear interpolation.

--- a/crates/hyperdrive-math/src/test_utils/preamble.rs
+++ b/crates/hyperdrive-math/src/test_utils/preamble.rs
@@ -87,7 +87,7 @@ fn get_max_long(state: State, maybe_max_num_tries: Option<usize>) -> Result<Fixe
     // So we will first attempt to use `calculate_max_long` and then we will double check and reduce
     // the max if necessary.
     let mut max_long = match panic::catch_unwind(|| {
-        state.calculate_max_long(U256::from(U128::MAX), checkpoint_exposure, Some(3))
+        state.calculate_max_long(U256::from(U128::MAX), checkpoint_exposure, Some(5))
     }) {
         Ok(max_long_no_panic) => match max_long_no_panic {
             Ok(max_long_no_err) => max_long_no_err,
@@ -158,7 +158,7 @@ pub fn get_max_short(
             state.vault_share_price(),
             checkpoint_exposure,
             Some(conservative_price),
-            Some(3),
+            Some(5),
         )
     }) {
         Ok(max_short_no_panic) => match max_short_no_panic {

--- a/crates/hyperdrive-math/src/test_utils/preamble.rs
+++ b/crates/hyperdrive-math/src/test_utils/preamble.rs
@@ -287,6 +287,10 @@ mod tests {
             if state.effective_share_reserves()?
                 < state.calculate_min_share_reserves(checkpoint_exposure)?
             {
+                chain.revert(id).await?;
+                alice.reset(Default::default()).await?;
+                bob.reset(Default::default()).await?;
+                celine.reset(Default::default()).await?;
                 continue;
             }
 

--- a/crates/hyperdrive-math/src/yield_space.rs
+++ b/crates/hyperdrive-math/src/yield_space.rs
@@ -29,7 +29,7 @@ pub trait YieldSpace {
     fn t(&self) -> FixedPoint<U256>;
 
     // The current spot price ignoring slippage.
-    fn calculate_spot_price(&self) -> Result<FixedPoint<U256>> {
+    fn calculate_spot_price_down(&self) -> Result<FixedPoint<U256>> {
         if self.y() <= fixed!(0) {
             return Err(eyre!("expected y={} > 0", self.y()));
         }

--- a/crates/hyperdrive-math/src/yield_space.rs
+++ b/crates/hyperdrive-math/src/yield_space.rs
@@ -28,12 +28,20 @@ pub trait YieldSpace {
     /// The YieldSpace time parameter.
     fn t(&self) -> FixedPoint<U256>;
 
-    // The current spot price ignoring slippage.
+    // The current spot price ignoring slippage, rounded down.
     fn calculate_spot_price_down(&self) -> Result<FixedPoint<U256>> {
         if self.y() <= fixed!(0) {
             return Err(eyre!("expected y={} > 0", self.y()));
         }
         ((self.mu() * self.ze()?) / self.y()).pow(self.t())
+    }
+
+    // The current spot price ignoring slippage, rounded up.
+    fn calculate_spot_price_up(&self) -> Result<FixedPoint<U256>> {
+        if self.y() <= fixed!(0) {
+            return Err(eyre!("expected y={} > 0", self.y()));
+        }
+        ((self.mu().mul_up(self.ze()?)).div_up(self.y())).pow(self.t())
     }
 
     /// Calculates the amount of bonds a user will receive from the pool by


### PR DESCRIPTION
improves the function for calculating the absolute max short.

We use a linear approximation that passes the test 99.67% of the time (7441/7465 passed). There is an additional loop to ensure the remaining tests pass. Future work should be to fix the linear estimate to remove this loop -- it should not be required if the theory & code are correct.

Additional changes:
- removed the solidity comparison test for `calculate_absolute_max_short`. This was failing in cases when solidity was successful and erroneous. The new (rust) starting point obtained by the approximate estimate can succeed when the old (solidity) function fails, and it can also result in a lower final value than the solidity version. Follow-up PRs will add more tests that concretely demonstrate tolerances for final solvency after opening the max short. Once we are happy with the Rust version, we can port the code back over to Solidity & add back the parity tests.
- improved docstrings & comments for format & variable consistency
- renamed `calculate_spot_price` to `calculate_spot_price_down` and added a `*_up` version -- this is helpful for over/under estimating the price in the approximation code.
- made functions for calculating the minimum share reserves and the total fees paid when opening a short to dry up duplicate versions.
- added a new check and cleaned up error messaging/comments in `solvency_after_short`
- modified final liquidity provision in preamble to ensure short is possible given exposure from earlier random trades.
- modified some tests ensure a short is possible before conducting the test

## Derivation of approximate function

![image](https://github.com/user-attachments/assets/8e5664d7-b2d0-46ed-ae18-2e3736166d5d)
![image](https://github.com/user-attachments/assets/57a07c55-7e4d-4235-b094-603a41a8db99)
![image](https://github.com/user-attachments/assets/18b9b1cf-2f0f-443f-a154-fa84a9f891c6)
![image](https://github.com/user-attachments/assets/978cb4e1-91c2-4c1a-85a3-ac7f79080bce)
![image](https://github.com/user-attachments/assets/5a8afadf-037b-42fb-9d1a-ffdf6ac829b0)

